### PR TITLE
Adding pip install instructions after the packages are published

### DIFF
--- a/qiskit-code-assistant-mcp-server/README.md
+++ b/qiskit-code-assistant-mcp-server/README.md
@@ -23,6 +23,16 @@ The server implements one tool:
 
 ## Installation
 
+### Install from PyPI
+
+The easiest way to install is via pip:
+
+```bash
+pip install qiskit-code-assistant-mcp-server
+```
+
+### Install from Source
+
 This project uses [uv](https://astral.sh/uv) for virtual environments and dependencies management. If you don't have `uv` installed, check out the instructions in <https://docs.astral.sh/uv/getting-started/installation/>
 
 ### Setting up the Project with uv

--- a/qiskit-ibm-runtime-mcp-server/README.md
+++ b/qiskit-ibm-runtime-mcp-server/README.md
@@ -16,6 +16,16 @@ A comprehensive Model Context Protocol (MCP) server that provides AI assistants 
 
 ## Installation
 
+### Install from PyPI
+
+The easiest way to install is via pip:
+
+```bash
+pip install qiskit-ibm-runtime-mcp-server
+```
+
+### Install from Source
+
 This project recommends using [uv](https://astral.sh/uv) for virtual environments and dependencies management. If you don't have `uv` installed, check out the instructions in <https://docs.astral.sh/uv/getting-started/installation/>
 
 ### Setting up the Project with uv


### PR DESCRIPTION
The 1st version of the packages have been published in Pypi:
1. https://pypi.org/project/qiskit-ibm-runtime-mcp-server/
2. https://pypi.org/project/qiskit-code-assistant-mcp-server/

This PR adds the instructions to install them via pip