### PR TITLE
feat: Add Python 3.13 and 3.14 to pyproject files and the CI test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     
     steps:
     - uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Physics",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]

--- a/qiskit-code-assistant-mcp-server/pyproject.toml
+++ b/qiskit-code-assistant-mcp-server/pyproject.toml
@@ -3,7 +3,7 @@ name = "qiskit-code-assistant-mcp-server"
 version = "0.1.0"
 description = "MCP server for the Qiskit Code Assistant"
 readme = "README.md"
-requires-python = ">=3.10,<4.0"
+requires-python = ">=3.10,<3.15"
 dependencies = [
     "fastmcp>=2.8.1",
     "python-dotenv>=1.0.0",
@@ -45,6 +45,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Physics",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]

--- a/qiskit-ibm-runtime-mcp-server/pyproject.toml
+++ b/qiskit-ibm-runtime-mcp-server/pyproject.toml
@@ -3,7 +3,7 @@ name = "qiskit-ibm-runtime-mcp-server"
 version = "0.1.0"
 description = "MCP server for IBM Quantum computing services through Qiskit IBM Runtime"
 readme = "README.md"
-requires-python = ">=3.10,<4.0"
+requires-python = ">=3.10,<3.15"
 dependencies = [
     "fastmcp>=2.8.1",
     "qiskit-ibm-runtime>=0.40.0",
@@ -45,6 +45,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Physics",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]


### PR DESCRIPTION
Add explicit support for Python 3.13 and 3.14. 

Fixes #35 