### PR TITLE
Adding tooling to publish automatically the `qiskit-ibm-transpiler-mcp-server`

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -15,6 +15,7 @@ on:
           - meta-package
           - code-assistant
           - runtime
+          - transpiler
 
 jobs:
   publish-code-assistant:
@@ -95,15 +96,55 @@ jobs:
         packages-dir: qiskit-ibm-runtime-mcp-server/dist/
         verbose: true
 
+  publish-transpiler:
+    if: |
+      (github.event_name == 'release' && contains(github.ref, 'transpiler')) ||
+      (github.event_name == 'workflow_dispatch' && (github.event.inputs.package == 'all' || github.event.inputs.package == 'transpiler'))
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for trusted publishing
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        version: "latest"
+
+    - name: Set up Python
+      run: uv python install 3.12
+
+    - name: Build package
+      working-directory: ./qiskit-ibm-transpiler-mcp-server
+      run: |
+        uv build --out-dir dist
+
+    - name: Verify build output
+      run: |
+        ls -la qiskit-ibm-transpiler-mcp-server/dist/
+        if [ ! -d "qiskit-ibm-transpiler-mcp-server/dist" ] || [ -z "$(ls -A qiskit-ibm-transpiler-mcp-server/dist)" ]; then
+          echo "ERROR: Build did not produce any distribution files"
+          exit 1
+        fi
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: qiskit-ibm-transpiler-mcp-server/dist/
+        verbose: true
+
   publish-meta-package:
     runs-on: ubuntu-latest
     # Meta-package should be published after individual servers
-    needs: [publish-code-assistant, publish-runtime]
+    needs: [publish-code-assistant, publish-runtime, publish-transpiler]
     # Allow meta-package to run even if individual packages were skipped (already published)
     if: |
       always() &&
       (needs.publish-code-assistant.result == 'success' || needs.publish-code-assistant.result == 'skipped') &&
       (needs.publish-runtime.result == 'success' || needs.publish-runtime.result == 'skipped') &&
+      (needs.publish-transpiler.result == 'success' || needs.publish-transpiler.result == 'skipped') &&
       ((github.event_name == 'release' && contains(github.ref, 'meta')) ||
        (github.event_name == 'workflow_dispatch' && (github.event.inputs.package == 'all' || github.event.inputs.package == 'meta-package')))
     permissions:

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -8,7 +8,8 @@ This repository contains multiple PyPI packages:
 
 1. **qiskit-code-assistant-mcp-server** - MCP server for Qiskit Code Assistant
 2. **qiskit-ibm-runtime-mcp-server** - MCP server for IBM Quantum Runtime
-3. **qiskit-mcp-servers** - Meta-package that installs all MCP servers
+3. **qiskit-ibm-transpiler-mcp-server** - MCP server for transpilation using the AI-powered transpiler passes.
+4. **qiskit-mcp-servers** - Meta-package that installs all MCP servers
 
 ### Meta-Package
 
@@ -21,6 +22,7 @@ pip install qiskit-mcp-servers
 # Or install individual servers via extras
 pip install qiskit-mcp-servers[code-assistant]  # Only Code Assistant
 pip install qiskit-mcp-servers[runtime]          # Only Runtime
+pip install qiskit-mcp-servers[transpiler]       # Only Transpiler
 ```
 
 ## Automated Publishing (Recommended)
@@ -54,10 +56,11 @@ Alternatively, you can create releases manually through the GitHub web interface
 1. Go to PyPI and create the project (if it doesn't exist):
    - For `qiskit-code-assistant-mcp-server`: https://pypi.org/manage/project/qiskit-code-assistant-mcp-server/settings/publishing/
    - For `qiskit-ibm-runtime-mcp-server`: https://pypi.org/manage/project/qiskit-ibm-runtime-mcp-server/settings/publishing/
+   - For `qiskit-ibm-transpiler-mcp-server`: https://pypi.org/manage/project/qiskit-ibm-transpiler-mcp-server/settings/publishing/
    - For `qiskit-mcp-servers`: https://pypi.org/manage/project/qiskit-mcp-servers/settings/publishing/
 
 2. Add a "trusted publisher" with these settings:
-   - **PyPI Project Name**: `qiskit-code-assistant-mcp-server` (or `qiskit-ibm-runtime-mcp-server` or `qiskit-mcp-servers`)
+   - **PyPI Project Name**: `qiskit-code-assistant-mcp-server` (or `qiskit-ibm-runtime-mcp-server`, `qiskit-ibm-transpiler-mcp-server`, or `qiskit-mcp-servers`)
    - **Owner**: `AI4quantum`
    - **Repository**: `mcp-servers`
    - **Workflow name**: `publish-pypi.yml`
@@ -73,6 +76,7 @@ The workflow automatically publishes when you create a GitHub release. The tag n
 |-------------|-------------------|
 | `code-assistant-v*` | qiskit-code-assistant-mcp-server |
 | `runtime-v*` | qiskit-ibm-runtime-mcp-server |
+| `transpiler-v*` | qiskit-ibm-transpiler-mcp-server |
 | `meta-v*` | qiskit-mcp-servers (meta-package) |
 
 #### Complete Release Workflow
@@ -84,6 +88,7 @@ Follow these steps to release a package:
 Edit the version in the appropriate `pyproject.toml`:
 - **Code Assistant**: `qiskit-code-assistant-mcp-server/pyproject.toml`
 - **Runtime**: `qiskit-ibm-runtime-mcp-server/pyproject.toml`
+- **Transpiler**: `qiskit-ibm-transpiler-mcp-server/pyproject.toml`
 - **Meta-package**: `pyproject.toml` (root)
 
 ##### Step 2: Commit and Push Changes
@@ -136,6 +141,14 @@ git tag -a runtime-v0.1.1 -m "Release v0.1.1" && git push origin runtime-v0.1.1
 gh release create runtime-v0.1.1 --title "qiskit-ibm-runtime-mcp-server v0.1.1" --generate-notes
 ```
 
+**Transpiler Server:**
+```bash
+# After updating version in qiskit-ibm-transpiler-mcp-server/pyproject.toml
+git add -A && git commit -m "Bump transpiler to v0.1.0" && git push origin main
+git tag -a transpiler-v0.1.0 -m "Release v0.1.0" && git push origin transpiler-v0.1.0
+gh release create transpiler-v0.1.0 --title "qiskit-ibm-transpiler-mcp-server v0.1.0" --generate-notes
+```
+
 **Meta-Package:**
 ```bash
 # After updating version in pyproject.toml (root)
@@ -158,6 +171,9 @@ gh workflow run "Publish to PyPI" -f package=code-assistant
 # Publish only runtime
 gh workflow run "Publish to PyPI" -f package=runtime
 
+# Publish only transpiler
+gh workflow run "Publish to PyPI" -f package=transpiler
+
 # Publish only meta-package
 gh workflow run "Publish to PyPI" -f package=meta-package
 ```
@@ -166,7 +182,7 @@ Alternatively, you can trigger via the GitHub web interface:
 
 1. Go to **Actions** → **Publish to PyPI**
 2. Click **Run workflow**
-3. Select which package to publish: `all`, `meta-package`, `code-assistant`, or `runtime`
+3. Select which package to publish: `all`, `meta-package`, `code-assistant`, `runtime`, or `transpiler`
 
 ## Manual Publishing
 
@@ -191,6 +207,7 @@ pip install uv
 Edit the version in `pyproject.toml`:
 - **Code Assistant**: `qiskit-code-assistant-mcp-server/pyproject.toml`
 - **Runtime**: `qiskit-ibm-runtime-mcp-server/pyproject.toml`
+- **Transpiler**: `qiskit-ibm-transpiler-mcp-server/pyproject.toml`
 - **Meta-package**: `pyproject.toml` (root)
 
 #### 2. Build the Package
@@ -209,6 +226,17 @@ python -m build
 **For Runtime:**
 ```bash
 cd qiskit-ibm-runtime-mcp-server
+
+# Build with uv (recommended)
+uv build
+
+# Or with build
+python -m build
+```
+
+**For Transpiler:**
+```bash
+cd qiskit-ibm-transpiler-mcp-server
 
 # Build with uv (recommended)
 uv build
@@ -250,6 +278,8 @@ twine upload --repository testpypi dist/*
 pip install --index-url https://test.pypi.org/simple/ qiskit-code-assistant-mcp-server
 # or
 pip install --index-url https://test.pypi.org/simple/ qiskit-ibm-runtime-mcp-server
+# or
+pip install --index-url https://test.pypi.org/simple/ qiskit-ibm-transpiler-mcp-server
 ```
 
 **Upload to production PyPI:**
@@ -272,6 +302,9 @@ pip install qiskit-code-assistant-mcp-server
 # For Runtime
 pip install qiskit-ibm-runtime-mcp-server
 
+# For Transpiler
+pip install qiskit-ibm-transpiler-mcp-server
+
 # For Meta-Package (installs all servers)
 pip install qiskit-mcp-servers
 ```
@@ -292,6 +325,7 @@ The current version for each package is defined in their respective `pyproject.t
 
 - **qiskit-code-assistant-mcp-server**: See [qiskit-code-assistant-mcp-server/pyproject.toml](qiskit-code-assistant-mcp-server/pyproject.toml) (search for `version =`)
 - **qiskit-ibm-runtime-mcp-server**: See [qiskit-ibm-runtime-mcp-server/pyproject.toml](qiskit-ibm-runtime-mcp-server/pyproject.toml) (search for `version =`)
+- **qiskit-ibm-transpiler-mcp-server**: See [qiskit-ibm-transpiler-mcp-server/pyproject.toml](qiskit-ibm-transpiler-mcp-server/pyproject.toml) (search for `version =`)
 - **qiskit-mcp-servers**: See [pyproject.toml](pyproject.toml) (search for `version =`)
 
 ## Pre-Publication Checklist

--- a/mypy.ini
+++ b/mypy.ini
@@ -48,7 +48,7 @@ incremental = True
 cache_dir = .mypy_cache
 
 # Paths to check
-files = qiskit-code-assistant-mcp-server/src,qiskit-ibm-runtime-mcp-server/src
+files = qiskit-code-assistant-mcp-server/src,qiskit-ibm-runtime-mcp-server/src,qiskit-ibm-transpiler-mcp-server/src
 
 # Exclude patterns
 exclude = (^\.venv/|^build/|^dist/|/tests/)
@@ -79,4 +79,7 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [mypy-dotenv.*]
+ignore_missing_imports = True
+
+[mypy-qiskit_ibm_transpiler.*]
 ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,16 +27,19 @@ classifiers = [
 dependencies = [
     "qiskit-code-assistant-mcp-server>=0.1.1",
     "qiskit-ibm-runtime-mcp-server>=0.1.2",
+    "qiskit-ibm-transpiler-mcp-server>=0.1.0",
 ]
 
 [project.optional-dependencies]
 # Install individual servers
 code-assistant = ["qiskit-code-assistant-mcp-server>=0.1.1"]
 runtime = ["qiskit-ibm-runtime-mcp-server>=0.1.2"]
+transpiler = ["qiskit-ibm-transpiler-mcp-server>=0.1.0"]
 # Install all servers (same as default dependencies)
 all = [
     "qiskit-code-assistant-mcp-server>=0.1.1",
     "qiskit-ibm-runtime-mcp-server>=0.1.2",
+    "qiskit-ibm-transpiler-mcp-server>=0.1.0",
 ]
 
 [project.urls]
@@ -57,12 +60,14 @@ packages = ["src/qiskit_mcp_servers"]
 members = [
     "qiskit-code-assistant-mcp-server",
     "qiskit-ibm-runtime-mcp-server",
+    "qiskit-ibm-transpiler-mcp-server",
 ]
 
 # Source configuration for workspace dependencies
 [tool.uv.sources]
 qiskit-code-assistant-mcp-server = { workspace = true }
 qiskit-ibm-runtime-mcp-server = { workspace = true }
+qiskit-ibm-transpiler-mcp-server = { workspace = true }
 
 # Shared tool configurations
 [tool.ruff]
@@ -74,7 +79,7 @@ extend = "ruff.toml"
 # Note: mypy doesn't support extend in pyproject.toml, see mypy.ini
 
 [tool.pytest.ini_options]
-testpaths = ["qiskit-code-assistant-mcp-server/tests", "qiskit-ibm-runtime-mcp-server/tests"]
+testpaths = ["qiskit-code-assistant-mcp-server/tests", "qiskit-ibm-runtime-mcp-server/tests", "qiskit-ibm-transpiler-mcp-server/tests"]
 python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"
@@ -96,7 +101,8 @@ markers = [
 [tool.coverage.run]
 source = [
     "qiskit-code-assistant-mcp-server/src",
-    "qiskit-ibm-runtime-mcp-server/src"
+    "qiskit-ibm-runtime-mcp-server/src",
+    "qiskit-ibm-transpiler-mcp-server/src"
 ]
 omit = [
     "*/tests/*",


### PR DESCRIPTION
# Description

After #27, this PR enables the mechanisms to publish automatically the new package `qiskit-ibm-transpiler-mcp-server` into Pypi

## Linked Issue(s)

Related to #7 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

NA

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
