### PR TITLE
Including qiskit-mcp-server into the qiskit-mcp-servers publish action

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -13,11 +13,51 @@ on:
         options:
           - all
           - meta-package
+          - qiskit
           - code-assistant
           - runtime
           - transpiler
 
 jobs:
+  publish-qiskit:
+    if: |
+      (github.event_name == 'release' && contains(github.ref, 'qiskit-v')) ||
+      (github.event_name == 'workflow_dispatch' && (github.event.inputs.package == 'all' || github.event.inputs.package == 'qiskit'))
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for trusted publishing
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        version: "latest"
+
+    - name: Set up Python
+      run: uv python install 3.12
+
+    - name: Build package
+      working-directory: ./qiskit-mcp-server
+      run: |
+        uv build --out-dir dist
+
+    - name: Verify build output
+      run: |
+        ls -la qiskit-mcp-server/dist/
+        if [ ! -d "qiskit-mcp-server/dist" ] || [ -z "$(ls -A qiskit-mcp-server/dist)" ]; then
+          echo "ERROR: Build did not produce any distribution files"
+          exit 1
+        fi
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: qiskit-mcp-server/dist/
+        verbose: true
+
   publish-code-assistant:
     if: |
       (github.event_name == 'release' && contains(github.ref, 'code-assistant')) ||
@@ -138,10 +178,11 @@ jobs:
   publish-meta-package:
     runs-on: ubuntu-latest
     # Meta-package should be published after individual servers
-    needs: [publish-code-assistant, publish-runtime, publish-transpiler]
+    needs: [publish-qiskit, publish-code-assistant, publish-runtime, publish-transpiler]
     # Allow meta-package to run even if individual packages were skipped (already published)
     if: |
       always() &&
+      (needs.publish-qiskit.result == 'success' || needs.publish-qiskit.result == 'skipped') &&
       (needs.publish-code-assistant.result == 'success' || needs.publish-code-assistant.result == 'skipped') &&
       (needs.publish-runtime.result == 'success' || needs.publish-runtime.result == 'skipped') &&
       (needs.publish-transpiler.result == 'success' || needs.publish-transpiler.result == 'skipped') &&


### PR DESCRIPTION
# Description

After last PR #62 , we're still missing the automated publish of the qiskit-mcp-server as part of the metapackage publish. Example: https://github.com/Qiskit/mcp-servers/actions/runs/20344950568/job/58454628392

This PR enables it

## Linked Issue(s)

Fixes #65

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
NA

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
