### PR TITLE
docs: fix trusted publisher owner in Publishing

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -67,7 +67,7 @@ Alternatively, you can create releases manually through the GitHub web interface
 
 2. Add a "trusted publisher" with these settings:
    - **PyPI Project Name**: `qiskit-mcp-server` (or `qiskit-code-assistant-mcp-server`, `qiskit-ibm-runtime-mcp-server`, `qiskit-ibm-transpiler-mcp-server`, `qiskit-gym-mcp-server`, or `qiskit-mcp-servers`)
-   - **Owner**: `AI4quantum`
+   - **Owner**: `Qiskit`
    - **Repository**: `mcp-servers`
    - **Workflow name**: `publish-pypi.yml`
    - **Environment name**: (leave blank)


### PR DESCRIPTION
# Description

Fix trusted publisher owner in Publishing document to Qiskit, as it's the org this repository belongs to.

## Linked Issue(s)

Fixes # (Issue)

## Type of change

Docs

# How Has This Been Tested?

NA

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
