### PR TITLE
docs: add documentation for account management tools

### DIFF
--- a/qiskit-ibm-runtime-mcp-server/README.md
+++ b/qiskit-ibm-runtime-mcp-server/README.md
@@ -262,8 +262,9 @@ Get list of available quantum backends.
 - Number of qubits, coupling map
 - Simulator vs. hardware designation
 
-### `least_busy_backend()`
-Get the current least busy IBM Quantum backend available
+#### `least_busy_backend()`
+Get the current least busy IBM Quantum backend available.
+
 **Returns:** The backend with the fewest number of pending jobs
 
 #### `get_backend_properties(backend_name: str)`
@@ -420,6 +421,7 @@ List all IBM Quantum accounts saved on disk.
 - `status`: "success" or "error"
 - `accounts`: Dictionary of saved accounts (keyed by account name)
 - Each account contains: channel, url, token (masked for security)
+- `message`: Status message
 
 **Note:** Tokens are masked in the response, showing only the last 4 characters.
 


### PR DESCRIPTION
## Summary

Add README documentation for the 6 account management tools added in PR #93:

- `list_saved_accounts` - List all saved IBM Quantum accounts
- `delete_saved_account` - Delete a saved account from disk
- `active_account_info` - Get info about the active account
- `active_instance_info` - Get the CRN of the active instance
- `available_instances` - List all available instances
- `usage_info` - Get usage statistics and quota info

Also documents that tokens are masked in responses for security.