### PR TITLE
Fix MCP Registry schema URL to current version

### DIFF
--- a/qiskit-code-assistant-mcp-server/server.json
+++ b/qiskit-code-assistant-mcp-server/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/draft/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.qiskit/qiskit-code-assistant-mcp-server",
   "title": "Qiskit Code Assistant MCP Server",
   "description": "MCP server for the Qiskit Code Assistant intelligent code completion",

--- a/qiskit-gym-mcp-server/server.json
+++ b/qiskit-gym-mcp-server/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/draft/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.qiskit/qiskit-gym-mcp-server",
   "title": "Qiskit Gym MCP Server",
   "description": "MCP server for qiskit-gym reinforcement learning quantum circuit synthesis",

--- a/qiskit-ibm-runtime-mcp-server/server.json
+++ b/qiskit-ibm-runtime-mcp-server/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/draft/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.qiskit/qiskit-ibm-runtime-mcp-server",
   "title": "Qiskit IBM Runtime MCP Server",
   "description": "MCP server for IBM Quantum computing services through Qiskit IBM Runtime",

--- a/qiskit-ibm-transpiler-mcp-server/server.json
+++ b/qiskit-ibm-transpiler-mcp-server/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/draft/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.qiskit/qiskit-ibm-transpiler-mcp-server",
   "title": "Qiskit IBM Transpiler MCP Server",
   "description": "MCP server for AI Transpiler IBM Quantum services",

--- a/qiskit-mcp-server/server.json
+++ b/qiskit-mcp-server/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/draft/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.qiskit/qiskit-mcp-server",
   "title": "Qiskit MCP Server",
   "description": "MCP server for Qiskit quantum computing with circuit serialization utilities",


### PR DESCRIPTION
## Summary

- Update all `server.json` files to use the current MCP Registry schema URL
- Fixes publishing failures caused by deprecated draft schema rejection

Fixes #115

## Changes

All 5 server.json files updated from:
```
https://static.modelcontextprotocol.io/schemas/draft/server.schema.json
```
to:
```
https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json
```