### PR TITLE
Increase num_qubits limit in find_optimal_qv_qubits from 10 to 20

### DIFF
--- a/qiskit-ibm-runtime-mcp-server/src/qiskit_ibm_runtime_mcp_server/ibm_runtime.py
+++ b/qiskit-ibm-runtime-mcp-server/src/qiskit_ibm_runtime_mcp_server/ibm_runtime.py
@@ -1726,7 +1726,7 @@ async def find_optimal_qv_qubits(
 
     Args:
         backend_name: Name of the backend (e.g., 'ibm_brisbane')
-        num_qubits: Number of qubits in the subgraph (default: 5, range: 2-10)
+        num_qubits: Number of qubits in the subgraph (default: 5, range: 2-20)
         num_results: Number of top subgraphs to return (default: 5, max: 20)
         metric: Scoring metric to optimize:
             - "qv_optimized": Balanced scoring for QV (connectivity + errors + coherence)
@@ -1746,8 +1746,8 @@ async def find_optimal_qv_qubits(
     global service
 
     try:
-        # Validate inputs - limit num_qubits to 10 for performance
-        num_qubits = _clamp(num_qubits, 2, 10)
+        # Validate inputs - limit num_qubits to 20 for performance
+        num_qubits = _clamp(num_qubits, 2, 20)
         num_results = _clamp(num_results, 1, 20)
 
         # Check for fake backends early


### PR DESCRIPTION
## Summary
- Increases the `num_qubits` parameter limit in `find_optimal_qv_qubits` from 10 to 20
- Updates the docstring to reflect the new valid range (2-20)
- Enables QV experiments with larger qubit counts for future quantum hardware improvements

## Rationale
The heavy-hex topology of IBM backends constrains the number of valid connected subgraphs, making searches for up to 20 qubits feasible in reasonable time. This provides headroom beyond current QV records (~QV-2048/11 qubits) while staying computationally tractable.

## Test plan
- [x] All 180 ibm-runtime tests pass

Fixes #127