### PR TITLE
fix: auto-initialize service in job status, results, and cancel tools

### DIFF
--- a/qiskit-ibm-runtime-mcp-server/src/qiskit_ibm_runtime_mcp_server/ibm_runtime.py
+++ b/qiskit-ibm-runtime-mcp-server/src/qiskit_ibm_runtime_mcp_server/ibm_runtime.py
@@ -1348,10 +1348,7 @@ async def get_job_status(job_id: str) -> dict[str, Any]:
 
     try:
         if service is None:
-            return {
-                "status": "error",
-                "message": "Failed to get job status: service not initialized",
-            }
+            service = initialize_service()
 
         job = service.job(job_id)
 
@@ -1400,10 +1397,7 @@ async def get_job_results(job_id: str) -> dict[str, Any]:
 
     try:
         if service is None:
-            return {
-                "status": "error",
-                "message": "Failed to get job results: service not initialized",
-            }
+            service = initialize_service()
 
         job = service.job(job_id)
         job_status = job.status()
@@ -1498,10 +1492,7 @@ async def cancel_job(job_id: str) -> dict[str, Any]:
 
     try:
         if service is None:
-            return {
-                "status": "error",
-                "message": "Failed to cancel job: service not initialized",
-            }
+            service = initialize_service()
 
         job = service.job(job_id)
         job.cancel()

--- a/qiskit-ibm-runtime-mcp-server/tests/test_server.py
+++ b/qiskit-ibm-runtime-mcp-server/tests/test_server.py
@@ -611,13 +611,19 @@ class TestGetJobStatus:
             assert result["job_status"] == "DONE"
 
     @pytest.mark.asyncio
-    async def test_get_job_status_no_service(self):
-        """Test job status retrieval when service is None."""
-        with patch("qiskit_ibm_runtime_mcp_server.ibm_runtime.service", None):
+    async def test_get_job_status_no_service(self, mock_runtime_service):
+        """Test job status auto-initializes service when None."""
+        with (
+            patch("qiskit_ibm_runtime_mcp_server.ibm_runtime.service", None),
+            patch(
+                "qiskit_ibm_runtime_mcp_server.ibm_runtime.initialize_service"
+            ) as mock_init,
+        ):
+            mock_init.return_value = mock_runtime_service
             result = await get_job_status("job_123")
 
-            assert result["status"] == "error"
-            assert "service not initialized" in result["message"]
+            mock_init.assert_called_once()
+            assert result["status"] == "success"
 
     @pytest.mark.asyncio
     async def test_get_job_status_job_not_found(self, mock_runtime_service):
@@ -653,13 +659,19 @@ class TestGetJobResults:
             assert result["execution_time"] == 1.5
 
     @pytest.mark.asyncio
-    async def test_get_job_results_no_service(self):
-        """Test job results retrieval when service is None."""
-        with patch("qiskit_ibm_runtime_mcp_server.ibm_runtime.service", None):
+    async def test_get_job_results_no_service(self, mock_runtime_service):
+        """Test job results auto-initializes service when None."""
+        with (
+            patch("qiskit_ibm_runtime_mcp_server.ibm_runtime.service", None),
+            patch(
+                "qiskit_ibm_runtime_mcp_server.ibm_runtime.initialize_service"
+            ) as mock_init,
+        ):
+            mock_init.return_value = mock_runtime_service
             result = await get_job_results("job_123")
 
-            assert result["status"] == "error"
-            assert "service not initialized" in result["message"]
+            mock_init.assert_called_once()
+            assert result["status"] == "success"
 
     @pytest.mark.asyncio
     async def test_get_job_results_job_pending(self, mock_runtime_service):
@@ -767,13 +779,19 @@ class TestCancelJob:
             assert "cancellation requested" in result["message"]
 
     @pytest.mark.asyncio
-    async def test_cancel_job_no_service(self):
-        """Test job cancellation when service is None."""
-        with patch("qiskit_ibm_runtime_mcp_server.ibm_runtime.service", None):
+    async def test_cancel_job_no_service(self, mock_runtime_service):
+        """Test job cancellation auto-initializes service when None."""
+        with (
+            patch("qiskit_ibm_runtime_mcp_server.ibm_runtime.service", None),
+            patch(
+                "qiskit_ibm_runtime_mcp_server.ibm_runtime.initialize_service"
+            ) as mock_init,
+        ):
+            mock_init.return_value = mock_runtime_service
             result = await cancel_job("job_123")
 
-            assert result["status"] == "error"
-            assert "service not initialized" in result["message"]
+            mock_init.assert_called_once()
+            assert result["status"] == "success"
 
     @pytest.mark.asyncio
     async def test_cancel_job_failure(self, mock_runtime_service):


### PR DESCRIPTION
## Summary

- `get_job_status`, `get_job_results`, and `cancel_job` now call `initialize_service()` when the global `service` is `None`, consistent with all other 14 functions in the module
- Updated tests to verify auto-initialization behavior instead of expecting error responses

## Motivation

These three functions were the only ones that returned a "service not initialized" error instead of auto-initializing. This broke any MCP client using **stdio transport**, where each tool call spawns a new server process (so `service` is always `None`). 

Closes #129

## Test plan

- [x] All 180 existing tests pass (1 skipped)
- [x] Updated `test_get_job_status_no_service`, `test_get_job_results_no_service`, and `test_cancel_job_no_service` to verify `initialize_service()` is called