### PR TITLE
docs: update repo-wide documentation for qiskit-docs-mcp-server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,13 +195,16 @@ Each MCP server follows this standard structure:
 **Core Files**:
 - `server.py`: FastMCP server with tool/resource definitions
 - `data_fetcher.py`: Documentation fetching and search functions (async)
+- `constants.py`: Module/guide/addon lists, error code categories, URL configuration
 
 **Tools Provided**:
 | Tool | Description |
 |------|-------------|
-| `get_sdk_module_docs_tool` | Get documentation for Qiskit SDK modules (circuit, primitives, transpiler, quantum_info, result, visualization) |
+| `get_sdk_module_docs_tool` | Get documentation for Qiskit SDK modules (circuit, quantum_info, transpiler, synthesis, primitives, result, visualization, and more) |
+| `get_addon_docs_tool` | Get documentation for Qiskit addon packages (sqd, cutting, mpf, obp, aqc-tensor, utils) |
 | `get_guide_tool` | Get Qiskit guides and best practices (optimization, error-mitigation, dynamic-circuits, etc.) |
 | `search_docs_tool` | Search Qiskit documentation for relevant content |
+| `lookup_error_code_tool` | Look up a Qiskit/IBM Quantum error code (e.g., 1002, 7001, 8004) |
 
 **Resources Provided**:
 | Resource URI | Description |
@@ -209,27 +212,42 @@ Each MCP server follows this standard structure:
 | `qiskit-docs://modules` | List of all Qiskit SDK modules |
 | `qiskit-docs://addons` | List of all Qiskit addon modules and tutorials |
 | `qiskit-docs://guides` | List of Qiskit guides and best practices |
+| `qiskit-docs://error-codes` | List of Qiskit error code categories |
 
 **Environment Variables**:
 - `QISKIT_DOCS_BASE`: Base URL for Qiskit documentation (default: https://quantum.cloud.ibm.com/docs/)
 - `QISKIT_HTTP_TIMEOUT`: HTTP request timeout in seconds (default: 10.0)
 - `QISKIT_SEARCH_BASE_URL`: Search API base URL (default: https://quantum.cloud.ibm.com/)
 
-**Available Modules**:
+**Available Modules** (17 total, see `constants.py` for canonical list):
 - `circuit`: Quantum circuit construction and manipulation
-- `primitives`: Sampler and Estimator primitives
-- `transpiler`: Circuit transpilation and optimization
 - `quantum_info`: Quantum information theory utilities
+- `transpiler`: Circuit transpilation and optimization
+- `synthesis`: Circuit synthesis algorithms
+- `dagcircuit`: DAG representation of circuits
+- `passmanager`: Pass manager framework
+- `converters`: Circuit format converters
+- `compiler`: High-level compilation functions
+- `primitives`: Sampler and Estimator primitives
+- `providers`: Backend provider interfaces
 - `result`: Job result handling
 - `visualization`: Circuit and result visualization
+- `qasm2`: OpenQASM 2.0 import/export
+- `qasm3`: OpenQASM 3.0 import/export
+- `qpy`: Qiskit Python serialization format
+- `utils`: Utility functions
+- `exceptions`: Qiskit exception classes
 
-**Available Guides**:
-- `optimization`: Quantum optimization techniques
-- `quantum-circuits`: Circuit design patterns
-- `error-mitigation`: Error mitigation strategies
-- `dynamic-circuits`: Mid-circuit measurements and classical control
-- `parametric-compilation`: Parameterized circuit compilation
-- `performance-tuning`: Performance optimization tips
+**Available Guides** (~40 total, see `constants.py` for canonical list, key categories):
+- Getting started: `quick-start`
+- Circuit building: `construct-circuits`
+- Transpilation: `transpile`, `transpiler-stages`, `transpile-with-pass-managers`, `defaults-and-configuration-options`, `circuit-transpilation-settings`, `qiskit-transpiler-service`
+- Error handling: `error-mitigation-and-suppression-techniques`, `configure-error-mitigation`, `configure-error-suppression`
+- Execution: `primitives`, `execution-modes`, `runtime-options-overview`, `directed-execution-model`
+- Dynamic circuits: `dynamic-circuits`
+- Qiskit Functions: `functions`, `ibm-circuit-function`, `algorithmiq-tem`, `qedma-qesem`, `q-ctrl-performance-management`, and more
+- Application functions: `colibritd-pde`, `global-data-quantum-optimizer`, `qunova-chemistry`, `kipu-optimization`, and more
+- Security: `secure-data`, `support`
 
 **Features**:
 - Fuzzy matching for module/guide names (suggests corrections for typos)
@@ -471,6 +489,7 @@ AI Assistant → MCP Client → create_*_env_tool → start_training_tool
    uv run qiskit-code-assistant-mcp-server
    uv run qiskit-ibm-runtime-mcp-server
    uv run qiskit-ibm-transpiler-mcp-server
+   uv run qiskit-docs-mcp-server
    uv run qiskit-gym-mcp-server
    ```
 
@@ -741,6 +760,7 @@ When adding a new MCP server, you must update the following GitHub configuration
    | qiskit-code-assistant-mcp-server | `code-assistant*` |
    | qiskit-ibm-runtime-mcp-server | `runtime*` |
    | qiskit-ibm-transpiler-mcp-server | `transpiler*` |
+   | qiskit-docs-mcp-server | `docs*` |
    | qiskit-gym-mcp-server | `gym*` |
    | Meta-package | `meta*` |
 
@@ -885,7 +905,7 @@ Each server is also published to the [MCP Registry](https://registry.modelcontex
 
 **Automated publishing** (recommended):
 - Publishing happens automatically via GitHub Actions when a release is created
-- Uses the same release tags as PyPI (`qiskit-v*`, `code-assistant*`, `runtime*`, `transpiler*`, `gym*`)
+- Uses the same release tags as PyPI (`qiskit-v*`, `code-assistant*`, `runtime*`, `transpiler*`, `docs*`, `gym*`)
 - Uses GitHub OIDC authentication (no secrets required)
 
 **Manual publishing**:
@@ -926,6 +946,7 @@ Each server has a `server.json` file that defines its MCP Registry metadata:
 - `qiskit-code-assistant-mcp-server/README.md`: Code Assistant server docs
 - `qiskit-ibm-runtime-mcp-server/README.md`: IBM Runtime server docs
 - `qiskit-ibm-transpiler-mcp-server/README.md`: IBM Transpiler server docs
+- `qiskit-docs-mcp-server/README.md`: Documentation server docs
 - `qiskit-gym-mcp-server/README.md`: Qiskit Gym RL server docs
 
 ### GitHub Configuration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,8 @@ Before you begin, ensure you have the following installed:
    # OR
    cd qiskit-ibm-transpiler-mcp-server
    # OR
+   cd qiskit-docs-mcp-server
+   # OR
    cd qiskit-gym-mcp-server
    ```
 
@@ -43,9 +45,9 @@ Before you begin, ensure you have the following installed:
    uv sync --group dev --group test
    ```
 
-4. **Configure environment variables**:
+4. **Configure environment variables** (if the server requires authentication):
    ```bash
-   cp .env.example .env
+   cp .env.example .env  # where available
    # Edit .env and add your IBM Quantum API token
    ```
 
@@ -58,6 +60,8 @@ Before you begin, ensure you have the following installed:
    uv run qiskit-ibm-runtime-mcp-server
    # OR
    uv run qiskit-ibm-transpiler-mcp-server
+   # OR
+   uv run qiskit-docs-mcp-server
    # OR
    uv run qiskit-gym-mcp-server
    ```
@@ -146,7 +150,7 @@ git commit -m "fix: description of bug that was fixed"
 ### Python Standards
 
 - **Python version**: 3.10+ features allowed
-- **Async/await**: Primary implementation for all MCP operations, with sync wrappers in `sync.py`
+- **Async/await**: Primary implementation for all MCP operations
 - **Type hints**: Required (mypy strict mode)
 - **Naming**: `snake_case` for functions/variables, `PascalCase` for classes
 - **Docstrings**: Google style for public functions
@@ -157,7 +161,7 @@ git commit -m "fix: description of bug that was fixed"
 - Tools are defined with `@mcp.tool()` decorator
 - Resources are defined with `@mcp.resource()` decorator
 - Async functions for all MCP handlers
-- Synchronous wrappers go in `sync.py` for DSPy/Jupyter compatibility
+- Use `nest_asyncio` when synchronous wrappers are needed for DSPy/Jupyter compatibility
 
 ### Error Handling
 
@@ -184,6 +188,7 @@ qiskit-mcp-servers/
 ├── qiskit-code-assistant-mcp-server/    # AI code completion server
 ├── qiskit-ibm-runtime-mcp-server/       # IBM Quantum cloud services
 ├── qiskit-ibm-transpiler-mcp-server/    # AI-powered transpilation
+├── qiskit-docs-mcp-server/              # Documentation retrieval
 ├── qiskit-gym-mcp-server/               # RL-based circuit synthesis (community)
 ├── README.md                            # Main documentation
 ├── CONTRIBUTING.md                      # This file
@@ -199,7 +204,6 @@ Each server follows this structure:
 │   ├── __init__.py          # Main entry point
 │   ├── server.py            # FastMCP server definition
 │   ├── <core>.py            # Core async functionality
-│   ├── sync.py              # Synchronous wrappers
 │   └── utils.py             # Utilities (optional)
 ├── tests/
 │   ├── conftest.py          # Test fixtures
@@ -230,22 +234,6 @@ async def my_new_tool(param: str) -> dict:
 async def my_resource() -> str:
     """Resource description."""
     return "resource content"
-```
-
-### Adding Synchronous Wrappers
-
-```python
-# In sync.py
-import nest_asyncio
-import asyncio
-from .core_module import async_function
-
-nest_asyncio.apply()
-
-def function_name_sync(*args, **kwargs):
-    """Synchronous wrapper for DSPy/Jupyter."""
-    loop = asyncio.get_event_loop()
-    return loop.run_until_complete(async_function(*args, **kwargs))
 ```
 
 ## Getting Help

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -10,8 +10,9 @@ This repository contains multiple PyPI packages:
 2. **qiskit-code-assistant-mcp-server** - MCP server for Qiskit Code Assistant
 3. **qiskit-ibm-runtime-mcp-server** - MCP server for IBM Quantum Runtime
 4. **qiskit-ibm-transpiler-mcp-server** - MCP server for transpilation using the AI-powered transpiler passes.
-5. **qiskit-gym-mcp-server** - MCP server for qiskit-gym reinforcement learning circuit synthesis
-6. **qiskit-mcp-servers** - Meta-package that installs all MCP servers
+5. **qiskit-docs-mcp-server** - MCP server for Qiskit documentation retrieval and search
+6. **qiskit-gym-mcp-server** - MCP server for qiskit-gym reinforcement learning circuit synthesis
+7. **qiskit-mcp-servers** - Meta-package that installs all MCP servers
 
 ### Meta-Package
 
@@ -26,6 +27,7 @@ pip install qiskit-mcp-servers[qiskit]           # Only Qiskit
 pip install qiskit-mcp-servers[code-assistant]   # Only Code Assistant
 pip install qiskit-mcp-servers[runtime]          # Only Runtime
 pip install qiskit-mcp-servers[transpiler]       # Only Transpiler
+pip install qiskit-mcp-servers[docs]             # Only Docs
 pip install qiskit-mcp-servers[gym]              # Only Gym (community)
 ```
 
@@ -62,11 +64,12 @@ Alternatively, you can create releases manually through the GitHub web interface
    - For `qiskit-code-assistant-mcp-server`: https://pypi.org/manage/project/qiskit-code-assistant-mcp-server/settings/publishing/
    - For `qiskit-ibm-runtime-mcp-server`: https://pypi.org/manage/project/qiskit-ibm-runtime-mcp-server/settings/publishing/
    - For `qiskit-ibm-transpiler-mcp-server`: https://pypi.org/manage/project/qiskit-ibm-transpiler-mcp-server/settings/publishing/
+   - For `qiskit-docs-mcp-server`: https://pypi.org/manage/project/qiskit-docs-mcp-server/settings/publishing/
    - For `qiskit-gym-mcp-server`: https://pypi.org/manage/project/qiskit-gym-mcp-server/settings/publishing/
    - For `qiskit-mcp-servers`: https://pypi.org/manage/project/qiskit-mcp-servers/settings/publishing/
 
 2. Add a "trusted publisher" with these settings:
-   - **PyPI Project Name**: `qiskit-mcp-server` (or `qiskit-code-assistant-mcp-server`, `qiskit-ibm-runtime-mcp-server`, `qiskit-ibm-transpiler-mcp-server`, `qiskit-gym-mcp-server`, or `qiskit-mcp-servers`)
+   - **PyPI Project Name**: `qiskit-mcp-server` (or `qiskit-code-assistant-mcp-server`, `qiskit-ibm-runtime-mcp-server`, `qiskit-ibm-transpiler-mcp-server`, `qiskit-docs-mcp-server`, `qiskit-gym-mcp-server`, or `qiskit-mcp-servers`)
    - **Owner**: `Qiskit`
    - **Repository**: `mcp-servers`
    - **Workflow name**: `publish-pypi.yml`
@@ -84,6 +87,7 @@ The workflow automatically publishes when you create a GitHub release. The tag n
 | `code-assistant-v*` | qiskit-code-assistant-mcp-server |
 | `runtime-v*` | qiskit-ibm-runtime-mcp-server |
 | `transpiler-v*` | qiskit-ibm-transpiler-mcp-server |
+| `docs-v*` | qiskit-docs-mcp-server |
 | `gym-v*` | qiskit-gym-mcp-server |
 | `meta-v*` | qiskit-mcp-servers (meta-package) |
 
@@ -98,6 +102,7 @@ Edit the version in the appropriate `pyproject.toml`:
 - **Code Assistant**: `qiskit-code-assistant-mcp-server/pyproject.toml`
 - **Runtime**: `qiskit-ibm-runtime-mcp-server/pyproject.toml`
 - **Transpiler**: `qiskit-ibm-transpiler-mcp-server/pyproject.toml`
+- **Docs**: `qiskit-docs-mcp-server/pyproject.toml`
 - **Gym**: `qiskit-gym-mcp-server/pyproject.toml`
 - **Meta-package**: `pyproject.toml` (root)
 
@@ -167,6 +172,14 @@ git tag -a transpiler-v0.1.0 -m "Release v0.1.0" && git push origin transpiler-v
 gh release create transpiler-v0.1.0 --title "qiskit-ibm-transpiler-mcp-server v0.1.0" --generate-notes
 ```
 
+**Docs Server:**
+```bash
+# After updating version in qiskit-docs-mcp-server/pyproject.toml
+git add -A && git commit -m "Bump docs to v0.1.0" && git push origin main
+git tag -a docs-v0.1.0 -m "Release v0.1.0" && git push origin docs-v0.1.0
+gh release create docs-v0.1.0 --title "qiskit-docs-mcp-server v0.1.0" --generate-notes
+```
+
 **Gym Server:**
 ```bash
 # After updating version in qiskit-gym-mcp-server/pyproject.toml
@@ -203,6 +216,9 @@ gh workflow run "Publish to PyPI" -f package=runtime
 # Publish only transpiler
 gh workflow run "Publish to PyPI" -f package=transpiler
 
+# Publish only docs
+gh workflow run "Publish to PyPI" -f package=docs
+
 # Publish only gym
 gh workflow run "Publish to PyPI" -f package=gym
 
@@ -214,7 +230,7 @@ Alternatively, you can trigger via the GitHub web interface:
 
 1. Go to **Actions** → **Publish to PyPI**
 2. Click **Run workflow**
-3. Select which package to publish: `all`, `meta-package`, `qiskit`, `code-assistant`, `runtime`, `transpiler`, or `gym`
+3. Select which package to publish: `all`, `meta-package`, `qiskit`, `code-assistant`, `runtime`, `transpiler`, `docs`, or `gym`
 
 ## Manual Publishing
 
@@ -241,6 +257,7 @@ Edit the version in `pyproject.toml`:
 - **Code Assistant**: `qiskit-code-assistant-mcp-server/pyproject.toml`
 - **Runtime**: `qiskit-ibm-runtime-mcp-server/pyproject.toml`
 - **Transpiler**: `qiskit-ibm-transpiler-mcp-server/pyproject.toml`
+- **Docs**: `qiskit-docs-mcp-server/pyproject.toml`
 - **Gym**: `qiskit-gym-mcp-server/pyproject.toml`
 - **Meta-package**: `pyproject.toml` (root)
 
@@ -282,6 +299,17 @@ python -m build
 **For Transpiler:**
 ```bash
 cd qiskit-ibm-transpiler-mcp-server
+
+# Build with uv (recommended)
+uv build
+
+# Or with build
+python -m build
+```
+
+**For Docs:**
+```bash
+cd qiskit-docs-mcp-server
 
 # Build with uv (recommended)
 uv build
@@ -339,6 +367,8 @@ pip install --index-url https://test.pypi.org/simple/ qiskit-ibm-runtime-mcp-ser
 # or
 pip install --index-url https://test.pypi.org/simple/ qiskit-ibm-transpiler-mcp-server
 # or
+pip install --index-url https://test.pypi.org/simple/ qiskit-docs-mcp-server
+# or
 pip install --index-url https://test.pypi.org/simple/ qiskit-gym-mcp-server
 ```
 
@@ -368,6 +398,9 @@ pip install qiskit-ibm-runtime-mcp-server
 # For Transpiler
 pip install qiskit-ibm-transpiler-mcp-server
 
+# For Docs
+pip install qiskit-docs-mcp-server
+
 # For Gym
 pip install qiskit-gym-mcp-server
 
@@ -379,7 +412,7 @@ pip install qiskit-mcp-servers
 
 ### Versioning Strategy
 
-Both packages use **semantic versioning**: `MAJOR.MINOR.PATCH`
+All packages use **semantic versioning**: `MAJOR.MINOR.PATCH`
 
 - **MAJOR**: Breaking changes to the API
 - **MINOR**: New features, backward compatible
@@ -393,6 +426,7 @@ The current version for each package is defined in their respective `pyproject.t
 - **qiskit-code-assistant-mcp-server**: See [qiskit-code-assistant-mcp-server/pyproject.toml](qiskit-code-assistant-mcp-server/pyproject.toml) (search for `version =`)
 - **qiskit-ibm-runtime-mcp-server**: See [qiskit-ibm-runtime-mcp-server/pyproject.toml](qiskit-ibm-runtime-mcp-server/pyproject.toml) (search for `version =`)
 - **qiskit-ibm-transpiler-mcp-server**: See [qiskit-ibm-transpiler-mcp-server/pyproject.toml](qiskit-ibm-transpiler-mcp-server/pyproject.toml) (search for `version =`)
+- **qiskit-docs-mcp-server**: See [qiskit-docs-mcp-server/pyproject.toml](qiskit-docs-mcp-server/pyproject.toml) (search for `version =`)
 - **qiskit-gym-mcp-server**: See [qiskit-gym-mcp-server/pyproject.toml](qiskit-gym-mcp-server/pyproject.toml) (search for `version =`)
 - **qiskit-mcp-servers**: See [pyproject.toml](pyproject.toml) (search for `version =`)
 
@@ -436,7 +470,7 @@ password = pypi-YOUR-API-TOKEN-HERE
 
 Make sure you're running build commands from the package directory:
 ```bash
-cd qiskit-mcp-server  # or qiskit-code-assistant-mcp-server, qiskit-ibm-runtime-mcp-server, qiskit-gym-mcp-server, etc.
+cd qiskit-mcp-server  # or qiskit-code-assistant-mcp-server, qiskit-docs-mcp-server, qiskit-gym-mcp-server, etc.
 uv build
 ```
 
@@ -467,6 +501,7 @@ gh workflow run "Publish to MCP Registry" -f package=qiskit
 gh workflow run "Publish to MCP Registry" -f package=code-assistant
 gh workflow run "Publish to MCP Registry" -f package=runtime
 gh workflow run "Publish to MCP Registry" -f package=transpiler
+gh workflow run "Publish to MCP Registry" -f package=docs
 gh workflow run "Publish to MCP Registry" -f package=gym
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![qiskit-ibm-runtime-mcp-server](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fregistry.modelcontextprotocol.io%2Fv0.1%2Fservers%2Fio.github.Qiskit%252Fqiskit-ibm-runtime-mcp-server%2Fversions%2Flatest&query=%24.server.version&label=qiskit-ibm-runtime-mcp-server&logo=modelcontextprotocol)](https://registry.modelcontextprotocol.io/?q=io.github.Qiskit%2Fqiskit-ibm-runtime-mcp-server)
 [![qiskit-ibm-transpiler-mcp-server](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fregistry.modelcontextprotocol.io%2Fv0.1%2Fservers%2Fio.github.Qiskit%252Fqiskit-ibm-transpiler-mcp-server%2Fversions%2Flatest&query=%24.server.version&label=qiskit-ibm-transpiler-mcp-server&logo=modelcontextprotocol)](https://registry.modelcontextprotocol.io/?q=io.github.Qiskit%2Fqiskit-ibm-transpiler-mcp-server)
 [![qiskit-code-assistant-mcp-server](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fregistry.modelcontextprotocol.io%2Fv0.1%2Fservers%2Fio.github.Qiskit%252Fqiskit-code-assistant-mcp-server%2Fversions%2Flatest&query=%24.server.version&label=qiskit-code-assistant-mcp-server&logo=modelcontextprotocol)](https://registry.modelcontextprotocol.io/?q=io.github.Qiskit%2Fqiskit-code-assistant-mcp-server)
+[![qiskit-docs-mcp-server](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fregistry.modelcontextprotocol.io%2Fv0.1%2Fservers%2Fio.github.Qiskit%252Fqiskit-docs-mcp-server%2Fversions%2Flatest&query=%24.server.version&label=qiskit-docs-mcp-server&logo=modelcontextprotocol)](https://registry.modelcontextprotocol.io/?q=io.github.Qiskit%2Fqiskit-docs-mcp-server)
 [![qiskit-gym-mcp-server](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fregistry.modelcontextprotocol.io%2Fv0.1%2Fservers%2Fio.github.Qiskit%252Fqiskit-gym-mcp-server%2Fversions%2Flatest&query=%24.server.version&label=qiskit-gym-mcp-server&logo=modelcontextprotocol)](https://registry.modelcontextprotocol.io/?q=io.github.Qiskit%2Fqiskit-gym-mcp-server)
 
 A collection of **Model Context Protocol (MCP)** servers that provide AI assistants, LLMs, and agents with seamless access to IBM Quantum services and Qiskit libraries for quantum computing development and research.
@@ -62,6 +63,15 @@ Access to the [qiskit-ibm-transpiler](https://github.com/Qiskit/qiskit-ibm-trans
 
 ---
 
+### 📚 Qiskit Documentation MCP Server
+**Qiskit documentation retrieval and search**
+
+Query and retrieve [Qiskit documentation](https://quantum.cloud.ibm.com/docs/), guides, and API references. No authentication required.
+
+**📁 Directory**: [`./qiskit-docs-mcp-server/`](./qiskit-docs-mcp-server/)
+
+---
+
 ## 🏋️ Community Servers
 
 ### 🏋️ Qiskit Gym MCP Server
@@ -81,6 +91,7 @@ Each MCP server includes example code demonstrating how to build AI agents using
 | Qiskit Code Assistant MCP Server | [`qiskit-code-assistant-mcp-server/examples/`](./qiskit-code-assistant-mcp-server/examples/) |
 | Qiskit IBM Runtime MCP Server | [`qiskit-ibm-runtime-mcp-server/examples/`](./qiskit-ibm-runtime-mcp-server/examples/) |
 | Qiskit IBM Transpiler MCP Server | [`qiskit-ibm-transpiler-mcp-server/examples/`](./qiskit-ibm-transpiler-mcp-server/examples/) |
+| Qiskit Documentation MCP Server | [`qiskit-docs-mcp-server/examples/`](./qiskit-docs-mcp-server/examples/) |
 | Qiskit Gym MCP Server (Community) | [`qiskit-gym-mcp-server/examples/`](./qiskit-gym-mcp-server/examples/) |
 
 Each examples directory contains:
@@ -116,6 +127,7 @@ pip install qiskit-mcp-servers[qiskit]          # Qiskit server only
 pip install qiskit-mcp-servers[code-assistant]  # Code Assistant server only
 pip install qiskit-mcp-servers[runtime]         # IBM Runtime server only
 pip install qiskit-mcp-servers[transpiler]      # IBM Transpiler server only
+pip install qiskit-mcp-servers[docs]            # Documentation server only
 pip install qiskit-mcp-servers[gym]             # Qiskit Gym server only (community)
 
 # Install community servers only
@@ -150,6 +162,12 @@ cd qiskit-ibm-transpiler-mcp-server
 uv run qiskit-ibm-transpiler-mcp-server
 ```
 
+#### 📚 Documentation Server
+```bash
+cd qiskit-docs-mcp-server
+uv run qiskit-docs-mcp-server
+```
+
 #### 🏋️ Qiskit Gym Server (Community)
 ```bash
 cd qiskit-gym-mcp-server
@@ -170,21 +188,49 @@ export QCA_TOOL_API_BASE="https://qiskit-code-assistant.quantum.ibm.com"
 
 #### Using with MCP Clients
 
-Both servers are compatible with any MCP client. Test interactively with MCP Inspector:
+All servers are compatible with any MCP client. Test interactively with MCP Inspector:
 
 ```bash
-# Test Code Assistant Server
-npx @modelcontextprotocol/inspector uv run qiskit-code-assistant-mcp-server
-
-# Test IBM Runtime Server
+# Replace <server-name> with any server command
+npx @modelcontextprotocol/inspector uv run qiskit-mcp-server
+npx @modelcontextprotocol/inspector uv run qiskit-docs-mcp-server
 npx @modelcontextprotocol/inspector uv run qiskit-ibm-runtime-mcp-server
+# etc.
 ```
+
+#### Claude Desktop / Cline Configuration
+
+Add to your MCP client configuration (e.g., `claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "qiskit": {
+      "command": "uvx",
+      "args": ["qiskit-mcp-server"]
+    },
+    "qiskit-docs": {
+      "command": "uvx",
+      "args": ["qiskit-docs-mcp-server"]
+    },
+    "qiskit-runtime": {
+      "command": "uvx",
+      "args": ["qiskit-ibm-runtime-mcp-server"],
+      "env": {
+        "QISKIT_IBM_TOKEN": "your_ibm_quantum_token_here"
+      }
+    }
+  }
+}
+```
+
+See each server's README for the full list of environment variables and configuration options.
 
 ## 🏗️ Architecture & Design
 
 ### 🎯 Unified Design Principles
 
-Both servers follow a **consistent, production-ready architecture**:
+All servers follow a **consistent, production-ready architecture**:
 
 - **🔄 Async-first**: Built with FastMCP for high-performance async operations
 - **🧪 Test-driven**: Comprehensive test suites with 65%+ coverage
@@ -194,7 +240,7 @@ Both servers follow a **consistent, production-ready architecture**:
 
 ### 🔌 MCP Protocol Support
 
-Both servers implement the full **Model Context Protocol specification**:
+All servers implement the full **Model Context Protocol specification**:
 
 - **🛠️ Tools**: Execute quantum operations (code completion, job submission, backend queries)
 - **📚 Resources**: Access quantum data (service status, backend information, model details)
@@ -205,17 +251,13 @@ Both servers implement the full **Model Context Protocol specification**:
 
 ### 🏃‍♂️ Running Tests
 ```bash
-# Run tests for Code Assistant server
-cd qiskit-code-assistant-mcp-server
-./run_tests.sh
-
-# Run tests for IBM Runtime server  
-cd qiskit-ibm-runtime-mcp-server
+# Run tests for any server
+cd qiskit-code-assistant-mcp-server  # or any server directory
 ./run_tests.sh
 ```
 
 ### 🔍 Code Quality
-Both servers maintain high code quality standards:
+All servers maintain high code quality standards:
 - **✅ Linting**: `ruff check` and `ruff format`  
 - **🛡️ Type checking**: `mypy src/`
 - **🧪 Testing**: `pytest` with async support and coverage reporting

--- a/examples/README.md
+++ b/examples/README.md
@@ -94,7 +94,7 @@ From the repository root, install all example dependencies (including the MCP se
 uv sync --group examples
 ```
 
-This installs `deepagents`, `langchain`, `langchain-mcp-adapters`, `langchain-anthropic`, `scipy`, and all Qiskit MCP servers.
+This installs `deepagents`, `langchain`, `langchain-mcp-adapters`, `langchain-anthropic`, and all Qiskit MCP servers. For the full QV protocol (`--num-circuits`), also install `scipy`: `pip install scipy`.
 
 ### Environment Variables
 
@@ -251,4 +251,6 @@ Each MCP server has simpler examples in its own directory:
 - [`qiskit-mcp-server/examples/`](../qiskit-mcp-server/examples/) - Local transpilation
 - [`qiskit-ibm-runtime-mcp-server/examples/`](../qiskit-ibm-runtime-mcp-server/examples/) - IBM Quantum Runtime
 - [`qiskit-ibm-transpiler-mcp-server/examples/`](../qiskit-ibm-transpiler-mcp-server/examples/) - AI transpilation
+- [`qiskit-docs-mcp-server/examples/`](../qiskit-docs-mcp-server/examples/) - Documentation retrieval
 - [`qiskit-code-assistant-mcp-server/examples/`](../qiskit-code-assistant-mcp-server/examples/) - Code generation
+- [`qiskit-gym-mcp-server/examples/`](../qiskit-gym-mcp-server/examples/) - RL-based circuit synthesis (community)

--- a/qiskit-docs-mcp-server/run_tests.sh
+++ b/qiskit-docs-mcp-server/run_tests.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+set -e
+
+echo "=== Qiskit Docs MCP Server Test Suite ==="
+echo ""
+
+# Install dependencies
+echo "Installing dependencies..."
+uv sync --group dev --group test
+
+# Linting
+echo ""
+echo "=== Running Linting ==="
+uv run ruff check src tests
+uv run ruff format --check src tests
+
+# Type checking
+echo ""
+echo "=== Running Type Checking ==="
+uv run mypy src
+
+# Unit tests
+echo ""
+echo "=== Running Unit Tests ==="
+uv run pytest tests/ -v -m "not integration" --cov=src --cov-report=term-missing
+
+# Integration tests (if any)
+echo ""
+echo "=== Running Integration Tests ==="
+uv run pytest tests/ -v -m "integration" --cov=src --cov-append --cov-report=term-missing || true
+
+# Generate coverage report
+echo ""
+echo "=== Generating Coverage Report ==="
+uv run pytest tests/ --cov=src --cov-report=html --cov-report=xml
+
+echo ""
+echo "=== All Tests Completed ==="


### PR DESCRIPTION
## Summary

- Add `qiskit-docs-mcp-server` references across all repo-wide documentation (README, CONTRIBUTING, PUBLISHING, AGENTS.md, examples/README)
- Fix pre-existing documentation inaccuracies found during audit:
  - Remove nonexistent `sync.py` references and "Adding Synchronous Wrappers" section from CONTRIBUTING.md
  - Update AGENTS.md docs server section with accurate module count (17, not 6) and guide count (~40, not 6)
  - Add missing `constants.py` to docs server core files in AGENTS.md
  - Fix "Both servers" → "All servers" language across README.md and PUBLISHING.md
  - Add missing gym server link in examples/README.md
  - Fix incorrect `scipy` dependency claim in examples/README.md (not in `uv sync --group examples`)