### PR TITLE
feat(qiskit-mcp-server): add load_circuit_from_qasm and export_circuit_to_qasm tools

### DIFF
--- a/qiskit-mcp-server/README.md
+++ b/qiskit-mcp-server/README.md
@@ -220,6 +220,10 @@ For more LLM providers (Anthropic, Google, Ollama, Watsonx) and detailed example
 | `transpile_circuit_tool` | Transpile a circuit with configurable optimization |
 | `analyze_circuit_tool` | Analyze circuit structure without transpiling |
 | `compare_optimization_levels_tool` | Compare all optimization levels (0-3) |
+| `load_circuit_from_qasm_tool` | Load a circuit from OpenQASM 2.0 or 3.0 string, returning QPY and metadata |
+| `export_circuit_to_qasm_tool` | Export a QPY circuit to OpenQASM 2.0 or 3.0 format |
+| `convert_qpy_to_qasm3_tool` | Convert a base64-encoded QPY circuit to QASM3 |
+| `convert_qasm3_to_qpy_tool` | Convert a QASM3 (or QASM2) circuit to base64-encoded QPY |
 
 ### Resources
 

--- a/qiskit-mcp-server/src/qiskit_mcp_server/__init__.py
+++ b/qiskit-mcp-server/src/qiskit_mcp_server/__init__.py
@@ -20,11 +20,16 @@ This package provides:
 from qiskit_mcp_server import server
 from qiskit_mcp_server.circuit_serialization import (
     CircuitFormat,
+    ExportQasmVersion,
+    QasmVersion,
     detect_circuit_format,
     dump_circuit,
     dump_qasm_circuit,
     dump_qpy_circuit,
+    export_circuit_to_qasm,
+    get_circuit_metadata,
     load_circuit,
+    load_circuit_from_qasm,
     load_qasm_circuit,
     load_qpy_circuit,
     qasm3_to_qpy,
@@ -40,11 +45,16 @@ def main() -> None:
 
 __all__ = [
     "CircuitFormat",
+    "ExportQasmVersion",
+    "QasmVersion",
     "detect_circuit_format",
     "dump_circuit",
     "dump_qasm_circuit",
     "dump_qpy_circuit",
+    "export_circuit_to_qasm",
+    "get_circuit_metadata",
     "load_circuit",
+    "load_circuit_from_qasm",
     "load_qasm_circuit",
     "load_qpy_circuit",
     "main",

--- a/qiskit-mcp-server/src/qiskit_mcp_server/circuit_serialization.py
+++ b/qiskit-mcp-server/src/qiskit_mcp_server/circuit_serialization.py
@@ -56,8 +56,10 @@ import logging
 from typing import Any, Literal
 
 from qiskit import QuantumCircuit, qpy
-from qiskit.qasm2 import dumps as qasm2_dumps, loads as qasm2_loads
-from qiskit.qasm3 import dumps as qasm3_dumps, loads as qasm3_loads
+from qiskit.qasm2 import dumps as qasm2_dumps
+from qiskit.qasm2 import loads as qasm2_loads
+from qiskit.qasm3 import dumps as qasm3_dumps
+from qiskit.qasm3 import loads as qasm3_loads
 
 
 logger = logging.getLogger(__name__)

--- a/qiskit-mcp-server/src/qiskit_mcp_server/circuit_serialization.py
+++ b/qiskit-mcp-server/src/qiskit_mcp_server/circuit_serialization.py
@@ -56,10 +56,8 @@ import logging
 from typing import Any, Literal
 
 from qiskit import QuantumCircuit, qpy
-from qiskit.qasm2 import dumps as qasm2_dumps
-from qiskit.qasm2 import loads as qasm2_loads
-from qiskit.qasm3 import dumps as qasm3_dumps
-from qiskit.qasm3 import loads as qasm3_loads
+from qiskit.qasm2 import dumps as qasm2_dumps, loads as qasm2_loads
+from qiskit.qasm3 import dumps as qasm3_dumps, loads as qasm3_loads
 
 
 logger = logging.getLogger(__name__)

--- a/qiskit-mcp-server/src/qiskit_mcp_server/circuit_serialization.py
+++ b/qiskit-mcp-server/src/qiskit_mcp_server/circuit_serialization.py
@@ -431,9 +431,7 @@ QasmVersion = Literal["auto", "2.0", "3.0"]
 ExportQasmVersion = Literal["2.0", "3.0"]
 
 
-def load_circuit_from_qasm(
-    qasm_string: str, qasm_version: QasmVersion = "auto"
-) -> dict[str, Any]:
+def load_circuit_from_qasm(qasm_string: str, qasm_version: QasmVersion = "auto") -> dict[str, Any]:
     """Load a quantum circuit from an OpenQASM string with version selection and metadata.
 
     Args:

--- a/qiskit-mcp-server/src/qiskit_mcp_server/circuit_serialization.py
+++ b/qiskit-mcp-server/src/qiskit_mcp_server/circuit_serialization.py
@@ -55,7 +55,9 @@ import io
 import logging
 from typing import Any, Literal
 
-from qiskit import QuantumCircuit, qasm2, qpy
+from qiskit import QuantumCircuit, qpy
+from qiskit.qasm2 import dumps as qasm2_dumps
+from qiskit.qasm2 import loads as qasm2_loads
 from qiskit.qasm3 import dumps as qasm3_dumps
 from qiskit.qasm3 import loads as qasm3_loads
 
@@ -155,7 +157,7 @@ def load_qasm_circuit(qasm_string: str) -> dict[str, Any]:
 
     # Fall back to QASM2
     try:
-        circuit = qasm2.loads(qasm_string)
+        circuit = qasm2_loads(qasm_string)
         return {"status": "success", "circuit": circuit}
     except Exception as qasm2_error:
         qasm2_error_msg = str(qasm2_error)
@@ -397,3 +399,158 @@ def qasm3_to_qpy(qasm_string: str) -> dict[str, Any]:
             "status": "error",
             "message": f"Failed to convert circuit to QPY: {e}",
         }
+
+
+def get_circuit_metadata(circuit: QuantumCircuit) -> dict[str, Any]:
+    """Extract metadata from a quantum circuit.
+
+    Args:
+        circuit: The quantum circuit to analyze.
+
+    Returns:
+        Dictionary with num_qubits, num_clbits, depth, size, width,
+        operation_counts, and total_operations.
+    """
+    op_counts: dict[str, int] = {}
+    for instruction in circuit.data:
+        name = instruction.operation.name
+        op_counts[name] = op_counts.get(name, 0) + 1
+
+    return {
+        "num_qubits": circuit.num_qubits,
+        "num_clbits": circuit.num_clbits,
+        "depth": circuit.depth(),
+        "size": circuit.size(),
+        "width": circuit.width(),
+        "operation_counts": op_counts,
+        "total_operations": sum(op_counts.values()),
+    }
+
+
+QasmVersion = Literal["auto", "2.0", "3.0"]
+ExportQasmVersion = Literal["2.0", "3.0"]
+
+
+def load_circuit_from_qasm(
+    qasm_string: str, qasm_version: QasmVersion = "auto"
+) -> dict[str, Any]:
+    """Load a quantum circuit from an OpenQASM string with version selection and metadata.
+
+    Args:
+        qasm_string: The OpenQASM source code (2.0 or 3.0).
+        qasm_version: Which parser to use:
+            - "auto" (default): Try QASM 3.0 first, fall back to QASM 2.0
+            - "3.0": Only try QASM 3.0 parser
+            - "2.0": Only try QASM 2.0 parser
+
+    Returns:
+        Dictionary with status, circuit_qpy, qasm_version_detected,
+        num_qubits, num_clbits, depth, size, width, operation_counts, total_operations.
+    """
+    circuit = None
+    version_detected = None
+
+    if qasm_version == "auto":
+        # Try QASM 3.0 first, fall back to QASM 2.0
+        try:
+            circuit = qasm3_loads(qasm_string)
+            version_detected = "3.0"
+        except Exception as qasm3_error:
+            logger.debug(f"QASM3 parsing failed: {qasm3_error}, trying QASM2")
+            try:
+                circuit = qasm2_loads(qasm_string)
+                version_detected = "2.0"
+            except Exception as qasm2_error:
+                return {
+                    "status": "error",
+                    "message": (
+                        f"QASM string not valid. "
+                        f"QASM3 error: {qasm3_error}; "
+                        f"QASM2 error: {qasm2_error}"
+                    ),
+                }
+    elif qasm_version == "3.0":
+        try:
+            circuit = qasm3_loads(qasm_string)
+            version_detected = "3.0"
+        except Exception as e:
+            return {
+                "status": "error",
+                "message": f"QASM 3.0 parsing failed: {e}",
+            }
+    elif qasm_version == "2.0":
+        try:
+            circuit = qasm2_loads(qasm_string)
+            version_detected = "2.0"
+        except Exception as e:
+            return {
+                "status": "error",
+                "message": f"QASM 2.0 parsing failed: {e}",
+            }
+    else:
+        return {
+            "status": "error",
+            "message": f"Invalid qasm_version: {qasm_version}. Must be 'auto', '2.0', or '3.0'.",
+        }
+
+    try:
+        circuit_qpy = dump_qpy_circuit(circuit)
+    except Exception as e:
+        return {
+            "status": "error",
+            "message": f"Failed to serialize circuit to QPY: {e}",
+        }
+
+    metadata = get_circuit_metadata(circuit)
+    return {
+        "status": "success",
+        "circuit_qpy": circuit_qpy,
+        "qasm_version_detected": version_detected,
+        **metadata,
+    }
+
+
+def export_circuit_to_qasm(
+    circuit_qpy: str, qasm_version: ExportQasmVersion = "3.0"
+) -> dict[str, Any]:
+    """Export a Qiskit circuit to OpenQASM format.
+
+    Args:
+        circuit_qpy: Base64-encoded QPY circuit.
+        qasm_version: Target QASM version ("2.0" or "3.0"). Default "3.0".
+
+    Returns:
+        Dictionary with status, qasm_string, qasm_version, num_qubits, depth.
+    """
+    load_result = load_qpy_circuit(circuit_qpy)
+    if load_result["status"] == "error":
+        return {
+            "status": "error",
+            "message": load_result["message"],
+        }
+
+    circuit = load_result["circuit"]
+
+    try:
+        if qasm_version == "3.0":
+            qasm_string = qasm3_dumps(circuit)
+        elif qasm_version == "2.0":
+            qasm_string = qasm2_dumps(circuit)
+        else:
+            return {
+                "status": "error",
+                "message": f"Invalid qasm_version: {qasm_version}. Must be '2.0' or '3.0'.",
+            }
+    except Exception as e:
+        return {
+            "status": "error",
+            "message": f"Failed to export circuit to QASM {qasm_version}: {e}",
+        }
+
+    return {
+        "status": "success",
+        "qasm_string": qasm_string,
+        "qasm_version": qasm_version,
+        "num_qubits": circuit.num_qubits,
+        "depth": circuit.depth(),
+    }

--- a/qiskit-mcp-server/src/qiskit_mcp_server/circuit_serialization.py
+++ b/qiskit-mcp-server/src/qiskit_mcp_server/circuit_serialization.py
@@ -476,7 +476,7 @@ def load_circuit_from_qasm(qasm_string: str, qasm_version: QasmVersion = "auto")
                 "status": "error",
                 "message": f"QASM 3.0 parsing failed: {e}",
             }
-    elif qasm_version == "2.0":
+    else:  # qasm_version == "2.0"
         try:
             circuit = qasm2_loads(qasm_string)
             version_detected = "2.0"
@@ -485,11 +485,6 @@ def load_circuit_from_qasm(qasm_string: str, qasm_version: QasmVersion = "auto")
                 "status": "error",
                 "message": f"QASM 2.0 parsing failed: {e}",
             }
-    else:
-        return {
-            "status": "error",
-            "message": f"Invalid qasm_version: {qasm_version}. Must be 'auto', '2.0', or '3.0'.",
-        }
 
     try:
         circuit_qpy = dump_qpy_circuit(circuit)
@@ -532,13 +527,8 @@ def export_circuit_to_qasm(
     try:
         if qasm_version == "3.0":
             qasm_string = qasm3_dumps(circuit)
-        elif qasm_version == "2.0":
+        else:  # qasm_version == "2.0"
             qasm_string = qasm2_dumps(circuit)
-        else:
-            return {
-                "status": "error",
-                "message": f"Invalid qasm_version: {qasm_version}. Must be '2.0' or '3.0'.",
-            }
     except Exception as e:
         return {
             "status": "error",

--- a/qiskit-mcp-server/src/qiskit_mcp_server/server.py
+++ b/qiskit-mcp-server/src/qiskit_mcp_server/server.py
@@ -29,7 +29,15 @@ from typing import Any
 
 from fastmcp import FastMCP
 
-from qiskit_mcp_server.circuit_serialization import CircuitFormat, qasm3_to_qpy, qpy_to_qasm3
+from qiskit_mcp_server.circuit_serialization import (
+    CircuitFormat,
+    ExportQasmVersion,
+    QasmVersion,
+    export_circuit_to_qasm,
+    load_circuit_from_qasm,
+    qasm3_to_qpy,
+    qpy_to_qasm3,
+)
 from qiskit_mcp_server.transpiler import (
     analyze_circuit,
     compare_optimization_levels,
@@ -184,6 +192,54 @@ async def convert_qasm3_to_qpy_tool(
         Dict with 'status' and 'circuit_qpy' (base64-encoded QPY string).
     """
     return qasm3_to_qpy(circuit_qasm)
+
+
+@mcp.tool()
+async def load_circuit_from_qasm_tool(
+    qasm_string: str,
+    qasm_version: QasmVersion = "auto",
+) -> dict[str, Any]:
+    """Load a quantum circuit from an OpenQASM 2.0 or 3.0 string.
+
+    Parses the QASM input, returns the circuit as base64-encoded QPY along with
+    metadata (qubit count, gate counts, depth) so you can reason about the circuit
+    before deciding what to do next.
+
+    Args:
+        qasm_string: The OpenQASM source code (2.0 or 3.0)
+        qasm_version: Which parser to use:
+            - "auto" (default): Try QASM 3.0 first, fall back to QASM 2.0
+            - "3.0": Only use the QASM 3.0 parser
+            - "2.0": Only use the QASM 2.0 parser
+
+    Returns:
+        Dict with 'status', 'circuit_qpy' (base64-encoded QPY), 'qasm_version_detected',
+        'num_qubits', 'num_clbits', 'depth', 'size', 'width', 'operation_counts', and 'total_operations'.
+    """
+    return load_circuit_from_qasm(qasm_string, qasm_version=qasm_version)
+
+
+@mcp.tool()
+async def export_circuit_to_qasm_tool(
+    circuit_qpy: str,
+    qasm_version: ExportQasmVersion = "3.0",
+) -> dict[str, Any]:
+    """Export a Qiskit circuit to OpenQASM format.
+
+    Converts a base64-encoded QPY circuit to human-readable OpenQASM text.
+    Supports both QASM 3.0 and QASM 2.0 output. Note that some circuits with
+    non-standard gates may not be expressible in QASM 2.0.
+
+    Args:
+        circuit_qpy: Base64-encoded QPY circuit string (from other tool outputs)
+        qasm_version: Target QASM version:
+            - "3.0" (default): Export as OpenQASM 3.0
+            - "2.0": Export as OpenQASM 2.0
+
+    Returns:
+        Dict with 'status', 'qasm_string', 'qasm_version', 'num_qubits', and 'depth'.
+    """
+    return export_circuit_to_qasm(circuit_qpy, qasm_version=qasm_version)
 
 
 # Resources - Static metadata accessible without tool calls

--- a/qiskit-mcp-server/src/qiskit_mcp_server/transpiler.py
+++ b/qiskit-mcp-server/src/qiskit_mcp_server/transpiler.py
@@ -29,6 +29,7 @@ from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit_mcp_server.circuit_serialization import (
     CircuitFormat,
     dump_circuit,
+    get_circuit_metadata,
     load_circuit,
 )
 from qiskit_mcp_server.utils import with_sync
@@ -131,26 +132,10 @@ def _circuit_to_dict(circuit: QuantumCircuit) -> dict[str, Any]:
     Returns:
         Dictionary with circuit information including QPY serialization
     """
-    # Get operation counts
-    op_counts: dict[str, int] = {}
-    for instruction in circuit.data:
-        op_name = instruction.operation.name
-        op_counts[op_name] = op_counts.get(op_name, 0) + 1
-
-    # Calculate depth
-    depth = circuit.depth()
-
-    # Serialize circuit in QPY format (source of truth)
+    metadata = get_circuit_metadata(circuit)
     qpy_str = dump_circuit(circuit, circuit_format="qpy")
-
     return {
-        "num_qubits": circuit.num_qubits,
-        "num_clbits": circuit.num_clbits,
-        "depth": depth,
-        "size": circuit.size(),
-        "width": circuit.width(),
-        "operation_counts": op_counts,
-        "total_operations": sum(op_counts.values()),
+        **metadata,
         "circuit_qpy": qpy_str,  # QPY format (use for chaining tools/servers)
     }
 

--- a/qiskit-mcp-server/tests/test_circuit_serialization.py
+++ b/qiskit-mcp-server/tests/test_circuit_serialization.py
@@ -18,7 +18,9 @@ from qiskit_mcp_server.circuit_serialization import (
     dump_circuit,
     dump_qasm_circuit,
     dump_qpy_circuit,
+    export_circuit_to_qasm,
     load_circuit,
+    load_circuit_from_qasm,
     load_qasm_circuit,
     load_qpy_circuit,
     qpy_to_qasm3,
@@ -42,6 +44,18 @@ include "stdgates.inc";
 qubit[2] q;
 h q[0];
 cx q[0], q[1];
+"""
+
+
+@pytest.fixture
+def valid_qasm2():
+    """Valid QASM 2.0 string."""
+    return """OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[2];
+creg c[2];
+h q[0];
+cx q[0],q[1];
 """
 
 
@@ -477,3 +491,198 @@ class TestAutoDetectionLoadCircuit:
         loaded = result["circuit"]
         assert loaded.num_qubits == simple_circuit.num_qubits
         assert loaded.depth() == simple_circuit.depth()
+
+
+class TestLoadCircuitFromQasm:
+    """Tests for load_circuit_from_qasm function."""
+
+    def test_auto_detect_qasm3(self, valid_qasm3):
+        """Test auto-detection with QASM 3.0 input."""
+        result = load_circuit_from_qasm(valid_qasm3)
+
+        assert result["status"] == "success"
+        assert result["qasm_version_detected"] == "3.0"
+        assert result["num_qubits"] == 2
+        assert "circuit_qpy" in result
+        assert "operation_counts" in result
+        assert "total_operations" in result
+        assert "depth" in result
+
+    def test_auto_detect_qasm2(self, valid_qasm2):
+        """Test auto-detection with QASM 2.0 input."""
+        result = load_circuit_from_qasm(valid_qasm2)
+
+        assert result["status"] == "success"
+        # QASM 2.0 may be parsed by either parser depending on version
+        assert result["qasm_version_detected"] in ("2.0", "3.0")
+        assert result["num_qubits"] == 2
+
+    def test_explicit_qasm3(self, valid_qasm3):
+        """Test explicit QASM 3.0 parsing."""
+        result = load_circuit_from_qasm(valid_qasm3, qasm_version="3.0")
+
+        assert result["status"] == "success"
+        assert result["qasm_version_detected"] == "3.0"
+        assert result["num_qubits"] == 2
+
+    def test_explicit_qasm2(self, valid_qasm2):
+        """Test explicit QASM 2.0 parsing."""
+        result = load_circuit_from_qasm(valid_qasm2, qasm_version="2.0")
+
+        assert result["status"] == "success"
+        assert result["qasm_version_detected"] == "2.0"
+        assert result["num_qubits"] == 2
+
+    def test_invalid_qasm(self, invalid_qasm3):
+        """Test invalid QASM input returns error."""
+        result = load_circuit_from_qasm(invalid_qasm3)
+
+        assert result["status"] == "error"
+        assert "message" in result
+
+    def test_invalid_qasm_explicit_version(self, invalid_qasm3):
+        """Test invalid QASM with explicit version returns error."""
+        result = load_circuit_from_qasm(invalid_qasm3, qasm_version="3.0")
+
+        assert result["status"] == "error"
+        assert "QASM 3.0 parsing failed" in result["message"]
+
+    def test_metadata_fields(self, valid_qasm3):
+        """Test that all expected metadata fields are present."""
+        result = load_circuit_from_qasm(valid_qasm3)
+
+        assert result["status"] == "success"
+        assert "num_qubits" in result
+        assert "num_clbits" in result
+        assert "depth" in result
+        assert "operation_counts" in result
+        assert "total_operations" in result
+        assert isinstance(result["operation_counts"], dict)
+        assert result["total_operations"] > 0
+
+    def test_circuit_qpy_is_loadable(self, valid_qasm3):
+        """Test that the returned circuit_qpy can be loaded back."""
+        result = load_circuit_from_qasm(valid_qasm3)
+
+        assert result["status"] == "success"
+        load_result = load_qpy_circuit(result["circuit_qpy"])
+        assert load_result["status"] == "success"
+        assert load_result["circuit"].num_qubits == result["num_qubits"]
+
+    def test_operation_counts_accuracy(self):
+        """Test that operation counts are accurate."""
+        qasm = """OPENQASM 3.0;
+include "stdgates.inc";
+qubit[3] q;
+h q[0];
+h q[1];
+cx q[0], q[1];
+cx q[1], q[2];
+"""
+        result = load_circuit_from_qasm(qasm)
+
+        assert result["status"] == "success"
+        assert result["operation_counts"]["h"] == 2
+        assert result["operation_counts"]["cx"] == 2
+        assert result["total_operations"] == 4
+
+
+class TestExportCircuitToQasm:
+    """Tests for export_circuit_to_qasm function."""
+
+    def test_export_qasm3_default(self, simple_circuit):
+        """Test default export to QASM 3.0."""
+        qpy_str = dump_qpy_circuit(simple_circuit)
+        result = export_circuit_to_qasm(qpy_str)
+
+        assert result["status"] == "success"
+        assert "OPENQASM" in result["qasm_string"]
+        assert result["qasm_version"] == "3.0"
+        assert result["num_qubits"] == 2
+        assert "depth" in result
+
+    def test_export_qasm3_explicit(self, simple_circuit):
+        """Test explicit QASM 3.0 export."""
+        qpy_str = dump_qpy_circuit(simple_circuit)
+        result = export_circuit_to_qasm(qpy_str, qasm_version="3.0")
+
+        assert result["status"] == "success"
+        assert result["qasm_version"] == "3.0"
+        assert "OPENQASM" in result["qasm_string"]
+
+    def test_export_qasm2(self, simple_circuit):
+        """Test export to QASM 2.0."""
+        qpy_str = dump_qpy_circuit(simple_circuit)
+        result = export_circuit_to_qasm(qpy_str, qasm_version="2.0")
+
+        assert result["status"] == "success"
+        assert result["qasm_version"] == "2.0"
+        assert "OPENQASM" in result["qasm_string"]
+        assert result["num_qubits"] == 2
+
+    def test_invalid_qpy(self):
+        """Test export with invalid QPY input."""
+        result = export_circuit_to_qasm("not-valid-base64!")
+
+        assert result["status"] == "error"
+        assert "message" in result
+
+    def test_export_qasm2_unsupported_circuit(self):
+        """Test that exporting a circuit with QASM3-only features to QASM 2.0 returns an error."""
+        # Circuit with if_test (classical bit condition) — not expressible in QASM 2.0
+        qc = QuantumCircuit(2, 1)
+        qc.h(0)
+        qc.measure(0, 0)
+        with qc.if_test((qc.clbits[0], True)):
+            qc.x(1)
+        qpy_str = dump_qpy_circuit(qc)
+
+        result = export_circuit_to_qasm(qpy_str, qasm_version="2.0")
+
+        assert result["status"] == "error"
+        assert "Failed to export circuit to QASM 2.0" in result["message"]
+
+    def test_export_qasm3_contains_valid_qasm(self, simple_circuit):
+        """Test that exported QASM 3.0 can be parsed back."""
+        qpy_str = dump_qpy_circuit(simple_circuit)
+        result = export_circuit_to_qasm(qpy_str, qasm_version="3.0")
+
+        assert result["status"] == "success"
+        # Verify the QASM can be loaded back
+        load_result = load_qasm_circuit(result["qasm_string"])
+        assert load_result["status"] == "success"
+        assert load_result["circuit"].num_qubits == simple_circuit.num_qubits
+
+    def test_export_qasm2_contains_valid_qasm(self, simple_circuit):
+        """Test that exported QASM 2.0 can be parsed back."""
+        qpy_str = dump_qpy_circuit(simple_circuit)
+        result = export_circuit_to_qasm(qpy_str, qasm_version="2.0")
+
+        assert result["status"] == "success"
+        # Verify the QASM can be loaded back
+        load_result = load_qasm_circuit(result["qasm_string"])
+        assert load_result["status"] == "success"
+        assert load_result["circuit"].num_qubits == simple_circuit.num_qubits
+
+    def test_round_trip_qasm3(self, valid_qasm3):
+        """Test full round-trip: QASM3 → QPY → QASM3."""
+        # Load QASM to QPY
+        load_result = load_circuit_from_qasm(valid_qasm3)
+        assert load_result["status"] == "success"
+
+        # Export back to QASM3
+        export_result = export_circuit_to_qasm(load_result["circuit_qpy"], qasm_version="3.0")
+        assert export_result["status"] == "success"
+        assert "OPENQASM" in export_result["qasm_string"]
+        assert export_result["num_qubits"] == load_result["num_qubits"]
+
+    def test_round_trip_qasm2(self, valid_qasm2):
+        """Test full round-trip: QASM2 → QPY → QASM2."""
+        # Load QASM to QPY
+        load_result = load_circuit_from_qasm(valid_qasm2, qasm_version="2.0")
+        assert load_result["status"] == "success"
+
+        # Export back to QASM2
+        export_result = export_circuit_to_qasm(load_result["circuit_qpy"], qasm_version="2.0")
+        assert export_result["status"] == "success"
+        assert "OPENQASM" in export_result["qasm_string"]


### PR DESCRIPTION
## Summary

- Add `load_circuit_from_qasm_tool` — parses OpenQASM 2.0/3.0 with version selection (`auto`/`2.0`/`3.0`), returns base64-encoded QPY plus circuit metadata (qubits, depth, operation counts)
- Add `export_circuit_to_qasm_tool` — exports QPY circuits to QASM 3.0 or QASM 2.0 (new capability), with clear error messages for circuits not expressible in QASM 2.0
- Extract shared `get_circuit_metadata()` into `circuit_serialization.py`, eliminating duplication with `transpiler._circuit_to_dict`
- Consistent `qasm2_loads`/`qasm2_dumps` direct imports (matching `qasm3_loads`/`qasm3_dumps` pattern)
- 18 new tests (94 total, all passing)

Fixes #145

## Test plan

- [x] `uv run pytest tests/test_circuit_serialization.py -v` — 56 tests pass
- [x] `uv run pytest tests/ -v` — 94 tests pass (including transpiler tests that use refactored `_circuit_to_dict`)
- [x] `uv run ruff check src/ tests/` — all checks pass