### PR TITLE
chore: bump qiskit v0.2.0, gym v0.3.0, docs v0.1.1, meta v0.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qiskit-mcp-servers"
-version = "0.8.0"
+version = "0.9.0"
 description = "Model Context Protocol servers for IBM Quantum services and Qiskit"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"
@@ -25,34 +25,34 @@ classifiers = [
 
 # Meta-package dependencies: installs all MCP servers
 dependencies = [
-    "qiskit-mcp-server>=0.1.2",
+    "qiskit-mcp-server>=0.2.0",
     "qiskit-code-assistant-mcp-server>=0.3.0",
-    "qiskit-docs-mcp-server>=0.1.0",
+    "qiskit-docs-mcp-server>=0.1.1",
     "qiskit-ibm-runtime-mcp-server>=0.5.0",
     "qiskit-ibm-transpiler-mcp-server>=0.3.1",
 ]
 
 [project.optional-dependencies]
 # Install individual servers
-qiskit = ["qiskit-mcp-server>=0.1.2"]
+qiskit = ["qiskit-mcp-server>=0.2.0"]
 code-assistant = ["qiskit-code-assistant-mcp-server>=0.3.0"]
-docs = ["qiskit-docs-mcp-server>=0.1.0"]
+docs = ["qiskit-docs-mcp-server>=0.1.1"]
 runtime = ["qiskit-ibm-runtime-mcp-server>=0.5.0"]
 transpiler = ["qiskit-ibm-transpiler-mcp-server>=0.3.1"]
-gym = ["qiskit-gym-mcp-server>=0.2.0"]
+gym = ["qiskit-gym-mcp-server>=0.3.0"]
 # Install all servers (core + community)
 all = [
-    "qiskit-mcp-server>=0.1.2",
+    "qiskit-mcp-server>=0.2.0",
     "qiskit-code-assistant-mcp-server>=0.3.0",
-    "qiskit-docs-mcp-server>=0.1.0",
+    "qiskit-docs-mcp-server>=0.1.1",
     "qiskit-ibm-runtime-mcp-server>=0.5.0",
     "qiskit-ibm-transpiler-mcp-server>=0.3.1",
-    "qiskit-gym-mcp-server>=0.2.0",
+    "qiskit-gym-mcp-server>=0.3.0",
 ]
 
 # Community servers
 community = [
-    "qiskit-gym-mcp-server>=0.2.0",
+    "qiskit-gym-mcp-server>=0.3.0",
 ]
 
 [project.urls]

--- a/qiskit-docs-mcp-server/pyproject.toml
+++ b/qiskit-docs-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qiskit-docs-mcp-server"
-version = "0.1.0"
+version = "0.1.1"
 description = "MCP server for Qiskit documentation retrieval and search"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/qiskit-docs-mcp-server/server.json
+++ b/qiskit-docs-mcp-server/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Qiskit/qiskit-docs-mcp-server",
   "title": "Qiskit Documentation MCP Server",
   "description": "MCP server for querying and retrieving Qiskit documentation, guides, and API references",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "websiteUrl": "https://github.com/Qiskit/mcp-servers/tree/main/qiskit-docs-mcp-server",
   "repository": {
     "url": "https://github.com/Qiskit/mcp-servers",
@@ -15,7 +15,7 @@
     {
       "registryType": "pypi",
       "identifier": "qiskit-docs-mcp-server",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/qiskit-gym-mcp-server/pyproject.toml
+++ b/qiskit-gym-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qiskit-gym-mcp-server"
-version = "0.2.0"
+version = "0.3.0"
 description = "MCP server for qiskit-gym reinforcement learning quantum circuit synthesis"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/qiskit-gym-mcp-server/server.json
+++ b/qiskit-gym-mcp-server/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Qiskit/qiskit-gym-mcp-server",
   "title": "Qiskit Gym MCP Server",
   "description": "MCP server for qiskit-gym reinforcement learning quantum circuit synthesis",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "websiteUrl": "https://github.com/Qiskit/mcp-servers/tree/main/qiskit-gym-mcp-server",
   "repository": {
     "url": "https://github.com/Qiskit/mcp-servers",
@@ -15,7 +15,7 @@
     {
       "registryType": "pypi",
       "identifier": "qiskit-gym-mcp-server",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/qiskit-mcp-server/pyproject.toml
+++ b/qiskit-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qiskit-mcp-server"
-version = "0.1.2"
+version = "0.2.0"
 description = "MCP server for Qiskit quantum computing capabilities with circuit serialization utilities"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/qiskit-mcp-server/server.json
+++ b/qiskit-mcp-server/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Qiskit/qiskit-mcp-server",
   "title": "Qiskit MCP Server",
   "description": "MCP server for Qiskit quantum computing with circuit serialization utilities",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "websiteUrl": "https://github.com/Qiskit/mcp-servers/tree/main/qiskit-mcp-server",
   "repository": {
     "url": "https://github.com/Qiskit/mcp-servers",
@@ -15,7 +15,7 @@
     {
       "registryType": "pypi",
       "identifier": "qiskit-mcp-server",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -4641,7 +4641,7 @@ test = [
 
 [[package]]
 name = "qiskit-docs-mcp-server"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "qiskit-docs-mcp-server" }
 dependencies = [
     { name = "fastmcp" },
@@ -4735,7 +4735,7 @@ wheels = [
 
 [[package]]
 name = "qiskit-gym-mcp-server"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "qiskit-gym-mcp-server" }
 dependencies = [
     { name = "fastmcp" },
@@ -5104,7 +5104,7 @@ test = [
 
 [[package]]
 name = "qiskit-mcp-server"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "qiskit-mcp-server" }
 dependencies = [
     { name = "fastmcp" },
@@ -5199,10 +5199,11 @@ test = [
 
 [[package]]
 name = "qiskit-mcp-servers"
-version = "0.7.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "qiskit-code-assistant-mcp-server" },
+    { name = "qiskit-docs-mcp-server" },
     { name = "qiskit-ibm-runtime-mcp-server" },
     { name = "qiskit-ibm-transpiler-mcp-server" },
     { name = "qiskit-mcp-server" },
@@ -5257,6 +5258,7 @@ requires-dist = [
     { name = "qiskit-code-assistant-mcp-server", editable = "qiskit-code-assistant-mcp-server" },
     { name = "qiskit-code-assistant-mcp-server", marker = "extra == 'all'", editable = "qiskit-code-assistant-mcp-server" },
     { name = "qiskit-code-assistant-mcp-server", marker = "extra == 'code-assistant'", editable = "qiskit-code-assistant-mcp-server" },
+    { name = "qiskit-docs-mcp-server", editable = "qiskit-docs-mcp-server" },
     { name = "qiskit-docs-mcp-server", marker = "extra == 'all'", editable = "qiskit-docs-mcp-server" },
     { name = "qiskit-docs-mcp-server", marker = "extra == 'docs'", editable = "qiskit-docs-mcp-server" },
     { name = "qiskit-gym-mcp-server", marker = "extra == 'all'", editable = "qiskit-gym-mcp-server" },
@@ -6308,6 +6310,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/8b/4b61d6e13f7108f36910df9ab4b58fd389cc2520d54d81b88660804aad99/torch-2.10.0-2-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:418997cb02d0a0f1497cf6a09f63166f9f5df9f3e16c8a716ab76a72127c714f", size = 79423467, upload-time = "2026-02-10T21:44:48.711Z" },
     { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
     { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ee/efbd56687be60ef9af0c9c0ebe106964c07400eade5b0af8902a1d8cd58c/torch-2.10.0-3-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a1ff626b884f8c4e897c4c33782bdacdff842a165fee79817b1dd549fdda1321", size = 915510070, upload-time = "2026-03-11T14:16:39.386Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ab/7b562f1808d3f65414cd80a4f7d4bb00979d9355616c034c171249e1a303/torch-2.10.0-3-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:ac5bdcbb074384c66fa160c15b1ead77839e3fe7ed117d667249afce0acabfac", size = 915518691, upload-time = "2026-03-11T14:15:43.147Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/abada41517ce0011775f0f4eacc79659bc9bc6c361e6bfe6f7052a6b9363/torch-2.10.0-3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:98c01b8bb5e3240426dcde1446eed6f40c778091c8544767ef1168fc663a05a6", size = 915622781, upload-time = "2026-03-11T14:17:11.354Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c6/4dfe238342ffdcec5aef1c96c457548762d33c40b45a1ab7033bb26d2ff2/torch-2.10.0-3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:80b1b5bfe38eb0e9f5ff09f206dcac0a87aadd084230d4a36eea5ec5232c115b", size = 915627275, upload-time = "2026-03-11T14:16:11.325Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/72bf18847f58f877a6a8acf60614b14935e2f156d942483af1ffc081aea0/torch-2.10.0-3-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:46b3574d93a2a8134b3f5475cfb98e2eb46771794c57015f6ad1fb795ec25e49", size = 915523474, upload-time = "2026-03-11T14:17:44.422Z" },
     { url = "https://files.pythonhosted.org/packages/0c/1a/c61f36cfd446170ec27b3a4984f072fd06dab6b5d7ce27e11adb35d6c838/torch-2.10.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:5276fa790a666ee8becaffff8acb711922252521b28fbce5db7db5cf9cb2026d", size = 145992962, upload-time = "2026-01-21T16:24:14.04Z" },
     { url = "https://files.pythonhosted.org/packages/b5/60/6662535354191e2d1555296045b63e4279e5a9dbad49acf55a5d38655a39/torch-2.10.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:aaf663927bcd490ae971469a624c322202a2a1e68936eb952535ca4cd3b90444", size = 915599237, upload-time = "2026-01-21T16:23:25.497Z" },
     { url = "https://files.pythonhosted.org/packages/40/b8/66bbe96f0d79be2b5c697b2e0b187ed792a15c6c4b8904613454651db848/torch-2.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:a4be6a2a190b32ff5c8002a0977a25ea60e64f7ba46b1be37093c141d9c49aeb", size = 113720931, upload-time = "2026-01-21T16:24:23.743Z" },


### PR DESCRIPTION
## Summary

- **qiskit-mcp-server** 0.1.2 → 0.2.0: New `load_circuit_from_qasm` and `export_circuit_to_qasm` tools with QASM 2.0/3.0 version selection and circuit metadata (#147)
- **qiskit-gym-mcp-server** 0.2.0 → 0.3.0: Curriculum overrides (`depth_slope`, `max_depth`), estimator feature, validation refactoring (#139, #105)
- **qiskit-docs-mcp-server** 0.1.0 → 0.1.1: `run_tests.sh` alignment with other servers, repo-wide docs update (#146)
- **qiskit-mcp-servers** (meta) 0.8.0 → 0.9.0: Updated dependency version pins