### PR TITLE
feat(docs-server): search-first redesign with 3 tools

### DIFF
--- a/qiskit-docs-mcp-server/README.md
+++ b/qiskit-docs-mcp-server/README.md
@@ -23,14 +23,12 @@ The Qiskit Documentation MCP Server provides AI assistants and agents with seaml
 
 ### Tools
 
-The server implements five tools for documentation access:
+The server implements three tools for documentation access:
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| `get_sdk_module_docs_tool` | Get documentation for Qiskit SDK modules | `module`: Module name (e.g., circuit, transpiler, quantum_info, primitives, synthesis, dagcircuit — see `qiskit-docs://modules` resource for full list) |
-| `get_addon_docs_tool` | Get documentation for Qiskit addon packages | `addon`: Addon name (e.g., sqd, cutting, mpf, obp, aqc-tensor) |
-| `get_guide_tool` | Get Qiskit implementation guides and best practices | `guide`: Guide name (e.g., quick-start, construct-circuits, transpile, configure-error-mitigation, dynamic-circuits — see `qiskit-docs://guides` resource for full list) |
-| `search_docs_tool` | Search Qiskit documentation for relevant content | `query`: Search query string<br>`module`: Search scope (default: "documentation") |
+| `search_docs_tool` | Search across the entire Qiskit documentation for relevant content | `query`: Search query string<br>`scope`: Search scope filter — `all` (default), `documentation`, `api`, `learning`, `tutorials` |
+| `get_page_tool` | Fetch any Qiskit documentation page and return as markdown | `url`: Full URL or relative path (e.g., `guides/transpile`, `api/qiskit/circuit`)<br>`max_length`: Max characters to return (default: 20000, 0 for unlimited)<br>`offset`: Character offset for pagination (default: 0) |
 | `lookup_error_code_tool` | Look up a Qiskit/IBM Quantum error code | `code`: 4-digit error code (e.g., 1002, 7001, 8004) |
 
 ### Resources
@@ -193,22 +191,6 @@ asyncio.run(main())
 
 ## Usage Examples
 
-### Get SDK Module Documentation
-
-```python
-# Query circuit module documentation
-result = await get_sdk_module_docs_tool("circuit")
-print(result["documentation"])
-```
-
-### Get Implementation Guide
-
-```python
-# Get error mitigation guide
-result = await get_guide_tool("configure-error-mitigation")
-print(result["documentation"])
-```
-
 ### Search Documentation
 
 ```python
@@ -216,7 +198,28 @@ print(result["documentation"])
 result = await search_docs_tool("transpiler optimization")
 print(f"Found {result['total_results']} results")
 for item in result["results"]:
-    print(f"- {item['name']}: {item['url']}")
+    print(f"- {item['title']}: {item['url']}")
+```
+
+### Fetch a Documentation Page
+
+```python
+# Fetch circuit module API reference
+result = await get_page_tool("api/qiskit/circuit")
+print(result["documentation"])
+
+# Fetch with pagination for large pages
+result = await get_page_tool("api/qiskit/circuit", max_length=5000)
+if result["has_more"]:
+    next_page = await get_page_tool("api/qiskit/circuit", offset=result["next_offset"])
+```
+
+### Look Up an Error Code
+
+```python
+# Look up error code 1002
+result = await lookup_error_code_tool("1002")
+print(result["details"])
 ```
 
 ## Available Documentation
@@ -262,14 +265,17 @@ for item in result["results"]:
 
 ## Features
 
-### Fuzzy Matching
+### Pagination Support
 
-The server includes intelligent fuzzy matching for module and guide names:
+Large documentation pages are automatically paginated. Use `max_length` and `offset` to control content retrieval:
 
 ```python
-# Typo in module name - server suggests correct spelling
-result = await get_sdk_module_docs_tool("circuitt")
-# Returns: {"status": "error", "suggestions": ["circuit"]}
+# Fetch first 5000 characters
+result = await get_page_tool("api/qiskit/circuit", max_length=5000)
+# result["has_more"] == True, result["next_offset"] == 5000
+
+# Fetch unlimited content
+result = await get_page_tool("api/qiskit/circuit", max_length=0)
 ```
 
 ### Metadata Inclusion
@@ -279,8 +285,10 @@ All responses include rich metadata:
 ```python
 {
     "status": "success",
-    "module": "circuit",
+    "url": "https://quantum.cloud.ibm.com/docs/api/qiskit/circuit",
     "documentation": "...",
+    "has_more": False,
+    "total_length": 15420,
     "metadata": {
         "url": "https://quantum.cloud.ibm.com/docs/api/qiskit/circuit",
         "timestamp": "2026-03-03T03:00:00Z",
@@ -345,10 +353,10 @@ See the [`examples/`](examples/) directory for complete working examples:
 export QISKIT_HTTP_TIMEOUT=30.0
 ```
 
-### Module Not Found
+### Page Not Found
 
-**Problem**: "Module 'xyz' not found"
-**Solution**: Check available modules using the `qiskit-docs://modules` resource or see the Available Documentation section above
+**Problem**: "Failed to fetch" error from `get_page_tool`
+**Solution**: Use `search_docs_tool` to find the correct URL, or check the `qiskit-docs://modules` and `qiskit-docs://guides` resources for valid paths
 
 ## Contributing
 

--- a/qiskit-docs-mcp-server/README.md
+++ b/qiskit-docs-mcp-server/README.md
@@ -12,7 +12,7 @@ The Qiskit Documentation MCP Server provides AI assistants and agents with seaml
 
 ### Key Features
 
-- **📚 Complete Documentation Access**: Query all Qiskit SDK modules (circuit, primitives, transpiler, quantum_info, result, visualization)
+- **📚 Complete Documentation Access**: Query all 16 Qiskit SDK modules, 6 addon packages, and 30+ implementation guides
 - **📖 Implementation Guides**: Access best practices for optimization, error mitigation, dynamic circuits, and more
 - **🔍 Smart Search**: Search across the entire Qiskit documentation with fuzzy matching
 - **🎯 No Authentication Required**: Public documentation access without API tokens
@@ -27,9 +27,9 @@ The server implements five tools for documentation access:
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| `get_sdk_module_docs_tool` | Get documentation for Qiskit SDK modules | `module`: Module name (circuit, primitives, transpiler, quantum_info, result, visualization) |
+| `get_sdk_module_docs_tool` | Get documentation for Qiskit SDK modules | `module`: Module name (e.g., circuit, transpiler, quantum_info, primitives, synthesis, dagcircuit — see `qiskit-docs://modules` resource for full list) |
 | `get_addon_docs_tool` | Get documentation for Qiskit addon packages | `addon`: Addon name (e.g., sqd, cutting, mpf, obp, aqc-tensor) |
-| `get_guide_tool` | Get Qiskit implementation guides and best practices | `guide`: Guide name (optimization, quantum-circuits, error-mitigation, dynamic-circuits, parametric-compilation, performance-tuning) |
+| `get_guide_tool` | Get Qiskit implementation guides and best practices | `guide`: Guide name (e.g., quick-start, construct-circuits, transpile, configure-error-mitigation, dynamic-circuits — see `qiskit-docs://guides` resource for full list) |
 | `search_docs_tool` | Search Qiskit documentation for relevant content | `query`: Search query string<br>`module`: Search scope (default: "documentation") |
 | `lookup_error_code_tool` | Look up a Qiskit/IBM Quantum error code | `code`: 4-digit error code (e.g., 1002, 7001, 8004) |
 
@@ -155,43 +155,37 @@ Add to your Cline MCP settings:
 
 > **Note:** To run LangChain examples you will need to install the dependencies:
 > ```bash
-> pip install langchain langchain-mcp-adapters langchain-openai python-dotenv
+> pip install langchain-mcp-adapters langchain-openai langgraph
 > ```
 
 ```python
 import asyncio
-from langchain.agents import create_agent
+
 from langchain_mcp_adapters.client import MultiServerMCPClient
-from langchain_mcp_adapters.tools import load_mcp_tools
 from langchain_openai import ChatOpenAI
+from langgraph.prebuilt import create_react_agent
 
 async def main():
     # Configure MCP client
-    mcp_client = MultiServerMCPClient({
-        "qiskit-docs": {
-            "transport": "stdio",
-            "command": "qiskit-docs-mcp-server",
-            "args": [],
+    async with MultiServerMCPClient(
+        {
+            "qiskit-docs": {
+                "command": "qiskit-docs-mcp-server",
+                "args": [],
+                "transport": "stdio",
+            }
         }
-    })
-
-    # Use persistent session for efficient tool calls
-    async with mcp_client.session("qiskit-docs") as session:
-        # Load MCP tools
-        tools = await load_mcp_tools(session)
-
-        # Create agent with LLM
-        llm = ChatOpenAI(model="gpt-4o", temperature=0)
-        agent = create_agent(
-            llm,
-            tools,
-            system_prompt="You are a helpful quantum computing documentation assistant."
+    ) as client:
+        # Create agent with LLM and MCP tools
+        agent = create_react_agent(
+            ChatOpenAI(model="gpt-4o"),
+            client.get_tools(),
         )
 
         # Query documentation
-        response = await agent.ainvoke({
-            "messages": [("user", "How do I create a quantum circuit in Qiskit?")]
-        })
+        response = await agent.ainvoke(
+            {"messages": [("user", "How do I create a quantum circuit in Qiskit?")]}
+        )
         print(response["messages"][-1].content)
 
 asyncio.run(main())
@@ -211,7 +205,7 @@ print(result["documentation"])
 
 ```python
 # Get error mitigation guide
-result = await get_guide_tool("error-mitigation")
+result = await get_guide_tool("configure-error-mitigation")
 print(result["documentation"])
 ```
 
@@ -232,22 +226,39 @@ for item in result["results"]:
 | Module | Description |
 |--------|-------------|
 | `circuit` | Quantum circuit construction and manipulation |
-| `primitives` | Sampler and Estimator primitives for quantum execution |
-| `transpiler` | Circuit transpilation and optimization |
 | `quantum_info` | Quantum information theory utilities |
+| `transpiler` | Circuit transpilation and optimization |
+| `synthesis` | Circuit synthesis algorithms |
+| `dagcircuit` | DAG representation of quantum circuits |
+| `passmanager` | Transpiler pass manager framework |
+| `converters` | Circuit format converters |
+| `compiler` | High-level compilation routines |
+| `primitives` | Sampler and Estimator primitives |
+| `providers` | Backend providers and job management |
 | `result` | Job result handling and analysis |
-| `visualization` | Circuit and result visualization tools |
+| `visualization` | Circuit and result visualization |
+| `qasm2` | OpenQASM 2.0 support |
+| `qasm3` | OpenQASM 3.0 support |
+| `qpy` | Qiskit Python serialization format |
+| `utils` | General utility functions |
+| `exceptions` | Qiskit exception classes |
 
 ### Implementation Guides
 
 | Guide | Description |
 |-------|-------------|
-| `optimization` | Quantum optimization techniques and algorithms |
-| `quantum-circuits` | Circuit design patterns and best practices |
-| `error-mitigation` | Error mitigation strategies for noisy quantum devices |
+| `quick-start` | Get started with Qiskit |
+| `construct-circuits` | Build and manipulate quantum circuits |
+| `transpile` | Transpile circuits for target backends |
+| `transpiler-stages` | Understand transpiler pipeline stages |
+| `configure-error-mitigation` | Configure error mitigation for primitives |
+| `configure-error-suppression` | Configure error suppression techniques |
+| `primitives` | Use Sampler and Estimator primitives |
+| `execution-modes` | Job, session, and batch execution modes |
 | `dynamic-circuits` | Mid-circuit measurements and classical control |
-| `parametric-compilation` | Parameterized circuit compilation techniques |
-| `performance-tuning` | Performance optimization tips and tricks |
+| `functions` | Overview of Qiskit Functions |
+
+> See the `qiskit-docs://guides` resource for the complete list of 30+ available guides.
 
 ## Features
 

--- a/qiskit-docs-mcp-server/pyproject.toml
+++ b/qiskit-docs-mcp-server/pyproject.toml
@@ -5,6 +5,7 @@ description = "MCP server for Qiskit documentation retrieval and search"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"
 dependencies = [
+    "beautifulsoup4>=4.12.0",
     "fastmcp>=2.8.1,<3",
     "html2text>=2020.1.16",
     "httpx>=0.28.1",

--- a/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/constants.py
+++ b/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/constants.py
@@ -57,6 +57,7 @@ ERROR_CODE_CATEGORIES = {
 
 # HTTP timeout configuration (in seconds)
 HTTP_TIMEOUT = _get_env_float("QISKIT_HTTP_TIMEOUT", 10.0)
+CACHE_TTL = _get_env_float("QISKIT_DOCS_CACHE_TTL", 3600.0)
 
 # Qiskit modules and their documentation paths
 AVAILABLE_MODULES = {

--- a/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/constants.py
+++ b/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/constants.py
@@ -59,83 +59,83 @@ ERROR_CODE_CATEGORIES = {
 HTTP_TIMEOUT = _get_env_float("QISKIT_HTTP_TIMEOUT", 10.0)
 
 # Qiskit modules and their documentation paths
-AVAILABLE_MODULES = [
+AVAILABLE_MODULES = {
     # Circuit construction
-    "circuit",
+    "circuit": "Quantum circuit construction and manipulation (QuantumCircuit, gates, registers)",
     # Quantum information
-    "quantum_info",
+    "quantum_info": "Quantum information utilities (states, operators, channels, measures)",
     # Transpilation
-    "transpiler",
-    "synthesis",
-    "dagcircuit",
-    "passmanager",
-    "converters",
-    "compiler",
+    "transpiler": "Circuit transpilation and optimization for target hardware",
+    "synthesis": "Circuit synthesis algorithms (unitary, Clifford, linear functions)",
+    "dagcircuit": "Directed acyclic graph (DAG) representation of quantum circuits",
+    "passmanager": "Transpiler pass manager framework for custom transpilation pipelines",
+    "converters": "Circuit format converters and interoperability utilities",
+    "compiler": "High-level compilation routines (transpile shortcut)",
     # Primitives and providers
-    "primitives",
-    "providers",
+    "primitives": "Sampler and Estimator primitives for quantum execution",
+    "providers": "Backend providers and job management interfaces",
     # Results and visualization
-    "result",
-    "visualization",
+    "result": "Quantum job result handling and analysis",
+    "visualization": "Circuit and result visualization tools",
     # Serialization
-    "qasm2",
-    "qasm3",
-    "qpy",
+    "qasm2": "OpenQASM 2.0 parsing and generation",
+    "qasm3": "OpenQASM 3.0 parsing and generation",
+    "qpy": "Qiskit Python serialization format (QPY) for circuit persistence",
     # Utilities
-    "utils",
-    "exceptions",
-]
+    "utils": "General utility functions and helpers",
+    "exceptions": "Qiskit exception classes and error hierarchy",
+}
 
-AVAILABLE_ADDONS = [
-    "aqc-tensor",
-    "cutting",
-    "mpf",
-    "obp",
-    "sqd",
-    "utils",
-]
+AVAILABLE_ADDONS = {
+    "aqc-tensor": "Approximate Quantum Compiler with tensor network techniques",
+    "cutting": "Circuit cutting to run large circuits on smaller devices",
+    "mpf": "Multi-product formulas for Hamiltonian simulation",
+    "obp": "Operator backpropagation for expectation value estimation",
+    "sqd": "Sample-based Quantum Diagonalization for chemistry and optimization",
+    "utils": "Shared utilities for Qiskit addon packages",
+}
 
-AVAILABLE_GUIDES = [
+AVAILABLE_GUIDES = {
     # Getting started
-    "quick-start",
+    "quick-start": "Get started with Qiskit — create and run your first circuit",
     # Circuit building
-    "construct-circuits",
+    "construct-circuits": "Build and manipulate quantum circuits",
     # Transpilation
-    "transpile",
-    "transpiler-stages",
-    "transpile-with-pass-managers",
-    "defaults-and-configuration-options",
-    "circuit-transpilation-settings",
-    "qiskit-transpiler-service",
+    "transpile": "Transpile circuits for target backends",
+    "transpiler-stages": "Understand the six stages of the transpiler pipeline",
+    "transpile-with-pass-managers": "Use custom pass managers for transpilation",
+    "defaults-and-configuration-options": "Transpiler defaults and configuration options",
+    "circuit-transpilation-settings": "Circuit-level transpilation settings",
+    "qiskit-transpiler-service": "Use the Qiskit Transpiler cloud service",
     # Error mitigation and suppression
-    "error-mitigation-and-suppression-techniques",
-    "configure-error-mitigation",
-    "configure-error-suppression",
+    "error-mitigation-and-suppression-techniques": "Overview of error mitigation and suppression techniques",
+    "configure-error-mitigation": "Configure error mitigation for Qiskit primitives",
+    "configure-error-suppression": "Configure error suppression techniques",
     # Execution
-    "primitives",
-    "execution-modes",
-    "runtime-options-overview",
-    "directed-execution-model",
+    "primitives": "Use Sampler and Estimator primitives for quantum execution",
+    "execution-modes": "Job, session, and batch execution modes",
+    "runtime-options-overview": "Overview of Qiskit Runtime configuration options",
+    "directed-execution-model": "Use the directed execution model",
     # Dynamic circuits
-    "dynamic-circuits",
+    "dynamic-circuits": "Mid-circuit measurements and classical control flow",
     # Post-processing addons
-    "qiskit-addons-sqd",
+    "qiskit-addons-sqd": "Use Sample-based Quantum Diagonalization (SQD)",
     # Qiskit Functions - circuit functions
-    "functions",
-    "ibm-circuit-function",
-    "algorithmiq-tem",
-    "qedma-qesem",
-    "q-ctrl-performance-management",
+    "functions": "Overview of Qiskit Functions",
+    "ibm-circuit-function": "IBM Circuit Function for optimized execution",
+    "algorithmiq-tem": "Algorithmiq Tensor Error Mitigation (TEM)",
+    "qedma-qesem": "Qedma Quantum Error Suppression and Error Mitigation (QESEM)",
+    "q-ctrl-performance-management": "Q-CTRL Performance Management for optimized circuits",
     # Qiskit Functions - application functions
-    "colibritd-pde",
-    "global-data-quantum-optimizer",
-    "qunova-chemistry",
-    "kipu-optimization",
-    "q-ctrl-optimization-solver",
-    "multiverse-computing-singularity",
+    "colibritd-pde": "ColibrITD PDE solver function",
+    "global-data-quantum-optimizer": "Global Data Quantum Optimizer function",
+    "qunova-chemistry": "Qunova Chemistry solver function",
+    "kipu-optimization": "Kipu Optimization solver function",
+    "q-ctrl-optimization-solver": "Q-CTRL Optimization Solver function",
+    "multiverse-computing-singularity": "Multiverse Computing Singularity function",
     # Security and support
-    "secure-data",
-    "support",
-]
+    "secure-data": "Data security and privacy on IBM Quantum",
+    "support": "Getting support and help with Qiskit and IBM Quantum",
+}
 
 SEARCH_PATH = "endpoints-docs-learning/api/search"

--- a/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/data_fetcher.py
+++ b/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/data_fetcher.py
@@ -121,7 +121,9 @@ def extract_main_content(html: str) -> str:
     # Remove skip-to-content links
     for element in soup.find_all("a", class_=lambda c: c and "skip" in c.lower()):
         element.decompose()
-    for element in soup.find_all("a", string=lambda s: s and "skip to" in s.lower()):
+    for element in soup.find_all(
+        "a", string=lambda s: s and "skip to" in s.lower()  # type: ignore[call-overload]
+    ):
         element.decompose()
 
     # Return the best semantic container
@@ -262,7 +264,7 @@ async def fetch_text(url: str) -> str | None:
     Returns:
         The text content of the page, or None if fetch fails
     """
-    cached = _text_cache.get(url)
+    cached: str | None = _text_cache.get(url)
     if cached is not None:
         return cached
 
@@ -290,7 +292,7 @@ async def fetch_text_json(url: str) -> list[dict[str, Any]] | None:
     Returns:
         The JSON content as a list of dicts, or None if fetch fails
     """
-    cached = _json_cache.get(url)
+    cached: list[dict[str, Any]] | None = _json_cache.get(url)
     if cached is not None:
         return cached
 
@@ -298,7 +300,7 @@ async def fetch_text_json(url: str) -> list[dict[str, Any]] | None:
         client = _get_http_client()
         response = await client.get(url, follow_redirects=True)
         response.raise_for_status()
-        result = response.json()
+        result: list[dict[str, Any]] = response.json()
         _json_cache.set(url, result)
         return result
     except httpx.HTTPError as e:

--- a/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/data_fetcher.py
+++ b/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/data_fetcher.py
@@ -122,7 +122,8 @@ def extract_main_content(html: str) -> str:
     for element in soup.find_all("a", class_=lambda c: c and "skip" in c.lower()):
         element.decompose()
     for element in soup.find_all(
-        "a", string=lambda s: s and "skip to" in s.lower()  # type: ignore[call-overload]
+        "a",
+        string=lambda s: s and "skip to" in s.lower(),  # type: ignore[call-overload]
     ):
         element.decompose()
 

--- a/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/data_fetcher.py
+++ b/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/data_fetcher.py
@@ -12,6 +12,7 @@
 
 import logging
 import re
+import time
 from datetime import datetime, timezone
 from typing import Any
 from urllib.parse import quote, urlparse
@@ -24,6 +25,7 @@ from qiskit_docs_mcp_server.constants import (
     AVAILABLE_GUIDES,
     AVAILABLE_MODULES,
     BASE_URL,
+    CACHE_TTL,
     ERROR_CODE_CATEGORIES,
     HTTP_TIMEOUT,
     QISKIT_DOCS_BASE,
@@ -35,6 +37,47 @@ logger = logging.getLogger(__name__)
 
 # Allowed hostname for URL validation (derived from configurable QISKIT_DOCS_BASE)
 _ALLOWED_HOST = urlparse(QISKIT_DOCS_BASE).netloc
+
+
+class _TTLCache:
+    """Simple in-memory cache with TTL and LRU eviction."""
+
+    def __init__(self, ttl: float = 3600.0, max_size: int = 128):
+        self._ttl = ttl
+        self._max_size = max_size
+        self._cache: dict[str, tuple[float, Any]] = {}
+
+    def get(self, key: str) -> Any | None:
+        if key in self._cache:
+            timestamp, value = self._cache[key]
+            if time.monotonic() - timestamp < self._ttl:
+                return value
+            del self._cache[key]
+        return None
+
+    def set(self, key: str, value: Any) -> None:
+        if len(self._cache) >= self._max_size and key not in self._cache:
+            oldest_key = min(self._cache, key=lambda k: self._cache[k][0])
+            del self._cache[oldest_key]
+        self._cache[key] = (time.monotonic(), value)
+
+    def clear(self) -> None:
+        self._cache.clear()
+
+
+_text_cache = _TTLCache(ttl=CACHE_TTL)
+_json_cache = _TTLCache(ttl=CACHE_TTL)
+
+_client_holder: dict[str, httpx.AsyncClient] = {}
+
+
+def _get_http_client() -> httpx.AsyncClient:
+    """Get or create a shared HTTP client."""
+    client = _client_holder.get("client")
+    if client is None or client.is_closed:
+        client = httpx.AsyncClient(timeout=HTTP_TIMEOUT, follow_redirects=True)
+        _client_holder["client"] = client
+    return client
 
 
 def _strip_html_tags(text: str) -> str:
@@ -163,11 +206,17 @@ async def fetch_text(url: str) -> str | None:
     Returns:
         The text content of the page, or None if fetch fails
     """
+    cached = _text_cache.get(url)
+    if cached is not None:
+        return cached
+
     try:
-        async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
-            response = await client.get(url, follow_redirects=True)
-            response.raise_for_status()
-            return response.text
+        client = _get_http_client()
+        response = await client.get(url, follow_redirects=True)
+        response.raise_for_status()
+        result = response.text
+        _text_cache.set(url, result)
+        return result
     except httpx.HTTPError as e:
         logger.error(f"Failed to fetch {url}: {e} because of a HTTP error.")
         return None
@@ -185,11 +234,17 @@ async def fetch_text_json(url: str) -> list[dict[str, Any]] | None:
     Returns:
         The JSON content as a list of dicts, or None if fetch fails
     """
+    cached = _json_cache.get(url)
+    if cached is not None:
+        return cached
+
     try:
-        async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
-            response = await client.get(url, follow_redirects=True)
-            response.raise_for_status()
-            return response.json()  # type: ignore[no-any-return]
+        client = _get_http_client()
+        response = await client.get(url, follow_redirects=True)
+        response.raise_for_status()
+        result = response.json()
+        _json_cache.set(url, result)
+        return result
     except httpx.HTTPError as e:
         logger.error(f"Failed to fetch {url}: {e} because of a HTTP error.")
         return None

--- a/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/data_fetcher.py
+++ b/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/data_fetcher.py
@@ -18,6 +18,7 @@ from urllib.parse import quote, urlparse
 
 import html2text
 import httpx
+from bs4 import BeautifulSoup
 
 from qiskit_docs_mcp_server.constants import (
     AVAILABLE_ADDONS,
@@ -49,8 +50,62 @@ def _strip_html_tags(text: str) -> str:
     return re.sub(r"<[^>]+>", "", text)
 
 
+def extract_main_content(html: str) -> str:
+    """Extract main content from HTML, removing navigation chrome.
+
+    Strips nav, header, footer, aside elements and ARIA-role navigation,
+    then returns the <main>, <article>, or role='main' content. Falls back
+    to <body> (with chrome removed) if no semantic main content is found.
+
+    Args:
+        html: Full HTML page content
+
+    Returns:
+        HTML string with only the main content
+    """
+    soup = BeautifulSoup(html, "html.parser")
+
+    # Remove structural chrome elements
+    for tag_name in ["nav", "header", "footer", "aside"]:
+        for element in soup.find_all(tag_name):
+            element.decompose()
+
+    # Remove ARIA-role navigation elements
+    for role in ["navigation", "banner", "contentinfo", "complementary"]:
+        for element in soup.find_all(attrs={"role": role}):
+            element.decompose()
+
+    # Remove skip-to-content links
+    for element in soup.find_all("a", class_=lambda c: c and "skip" in c.lower()):
+        element.decompose()
+    for element in soup.find_all("a", string=lambda s: s and "skip to" in s.lower()):
+        element.decompose()
+
+    # Return the best semantic container
+    main_content = soup.find("main")
+    if main_content:
+        return str(main_content)
+
+    article = soup.find("article")
+    if article:
+        return str(article)
+
+    main_role = soup.find(attrs={"role": "main"})
+    if main_role:
+        return str(main_role)
+
+    body = soup.find("body")
+    if body:
+        return str(body)
+
+    return str(soup)
+
+
 def convert_html_to_markdown(html: str) -> str:
     """Convert HTML content to Markdown format.
+
+    Strips navigation chrome (header, footer, nav, aside) before conversion
+    to produce cleaner markdown output.
 
     Args:
         html: HTML content string
@@ -58,11 +113,12 @@ def convert_html_to_markdown(html: str) -> str:
     Returns:
         Markdown formatted content
     """
+    content_html = extract_main_content(html)
     h = html2text.HTML2Text()
     h.ignore_links = False
     h.body_width = 0
     h.ignore_images = False
-    return h.handle(html)
+    return h.handle(content_html)
 
 
 def _truncate_content(content: str, max_length: int = 20000, offset: int = 0) -> dict[str, Any]:

--- a/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/data_fetcher.py
+++ b/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/data_fetcher.py
@@ -33,8 +33,8 @@ from qiskit_docs_mcp_server.constants import (
 
 logger = logging.getLogger(__name__)
 
-# Allowed hostname for URL validation
-_ALLOWED_HOST = "quantum.cloud.ibm.com"
+# Allowed hostname for URL validation (derived from configurable QISKIT_DOCS_BASE)
+_ALLOWED_HOST = urlparse(QISKIT_DOCS_BASE).netloc
 
 
 def _strip_html_tags(text: str) -> str:
@@ -63,6 +63,61 @@ def convert_html_to_markdown(html: str) -> str:
     h.body_width = 0
     h.ignore_images = False
     return h.handle(html)
+
+
+def _truncate_content(content: str, max_length: int = 20000, offset: int = 0) -> dict[str, Any]:
+    """Truncate content with pagination metadata.
+
+    Args:
+        content: The full content string
+        max_length: Maximum number of characters to return (0 for unlimited)
+        offset: Character offset to start from (negative values clamped to 0)
+
+    Returns:
+        Dict with 'content', 'has_more', 'offset', 'next_offset', 'total_length'
+    """
+    # Clamp invalid inputs
+    offset = max(0, offset)
+    max_length = max(0, max_length)
+
+    total_length = len(content)
+
+    if max_length <= 0:
+        return {
+            "content": content[offset:] if offset > 0 else content,
+            "has_more": False,
+            "offset": offset,
+            "next_offset": None,
+            "total_length": total_length,
+        }
+
+    # Apply offset
+    sliced = content[offset:]
+
+    if len(sliced) <= max_length:
+        return {
+            "content": sliced,
+            "has_more": False,
+            "offset": offset,
+            "next_offset": None,
+            "total_length": total_length,
+        }
+
+    # Truncate at a line boundary if possible
+    truncated = sliced[:max_length]
+    last_newline = truncated.rfind("\n")
+    if last_newline > max_length * 0.8:  # Only snap to newline if reasonably close
+        truncated = truncated[: last_newline + 1]
+
+    next_offset = offset + len(truncated)
+
+    return {
+        "content": truncated,
+        "has_more": True,
+        "offset": offset,
+        "next_offset": next_offset,
+        "total_length": total_length,
+    }
 
 
 def _resolve_url(url: str) -> str:
@@ -140,15 +195,17 @@ async def fetch_text_json(url: str) -> list[dict[str, Any]] | None:
         return None
 
 
-async def get_page_docs(url: str) -> dict[str, Any]:
+async def get_page_docs(url: str, max_length: int = 20000, offset: int = 0) -> dict[str, Any]:
     """Fetch any Qiskit documentation page and return as markdown.
 
     Accepts full URLs or relative paths. Validates that the URL is within
-    the allowed documentation domain.
+    the allowed documentation domain. Supports pagination for large pages.
 
     Args:
         url: Full URL or relative path (e.g., 'guides/transpile',
             'api/qiskit/circuit', 'api/qiskit/qiskit.circuit.QuantumCircuit')
+        max_length: Maximum number of characters to return (0 for unlimited)
+        offset: Character offset to start from for pagination
 
     Returns:
         Documentation content in markdown with metadata, or error status
@@ -179,15 +236,21 @@ async def get_page_docs(url: str) -> dict[str, Any]:
 
     docs = convert_html_to_markdown(html)
 
+    # Apply pagination
+    paginated = _truncate_content(docs, max_length=max_length, offset=offset)
+
     return {
         "status": "success",
         "url": resolved_url,
-        "documentation": docs,
+        "documentation": paginated["content"],
+        "has_more": paginated["has_more"],
+        "next_offset": paginated["next_offset"],
+        "total_length": paginated["total_length"],
         "metadata": {
             "url": resolved_url,
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "content_type": "markdown",
-            "content_length": len(docs),
+            "content_length": len(paginated["content"]),
         },
     }
 
@@ -218,19 +281,22 @@ async def search_qiskit_docs(query: str, scope: str = "all") -> dict[str, Any]:
             },
         }
 
-    # Strip HTML tags from search result fields
-    for result_item in results:
-        if "title" in result_item:
-            result_item["title"] = _strip_html_tags(result_item["title"])
-        if "text" in result_item:
-            result_item["text"] = _strip_html_tags(result_item["text"])
+    # Strip HTML tags from search result fields (shallow copy to avoid mutating cached data)
+    cleaned = []
+    for item in results:
+        entry = dict(item)
+        if "title" in entry:
+            entry["title"] = _strip_html_tags(entry["title"])
+        if "text" in entry:
+            entry["text"] = _strip_html_tags(entry["text"])
+        cleaned.append(entry)
 
     return {
         "status": "success",
         "query": query,
         "scope": scope,
-        "results": results,
-        "total_results": len(results),
+        "results": cleaned,
+        "total_results": len(cleaned),
         "metadata": {
             "url": url,
             "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -302,28 +368,35 @@ async def lookup_error_code(code: str) -> dict[str, Any]:
 
 
 def get_list_of_modules() -> dict[str, Any]:
-    """Get list of all Qiskit SDK modules with URL paths."""
+    """Get list of all Qiskit SDK modules with descriptions and URL paths."""
     return {
         "status": "success",
-        "modules": [{"name": name, "url_path": f"api/qiskit/{name}"} for name in AVAILABLE_MODULES],
+        "modules": [
+            {"name": name, "description": desc, "url_path": f"api/qiskit/{name}"}
+            for name, desc in AVAILABLE_MODULES.items()
+        ],
     }
 
 
 def get_list_of_addons() -> dict[str, Any]:
-    """Get list of all Qiskit addon modules with URL paths."""
+    """Get list of all Qiskit addon modules with descriptions and URL paths."""
     return {
         "status": "success",
         "addons": [
-            {"name": name, "url_path": f"api/qiskit-addon-{name}"} for name in AVAILABLE_ADDONS
+            {"name": name, "description": desc, "url_path": f"api/qiskit-addon-{name}"}
+            for name, desc in AVAILABLE_ADDONS.items()
         ],
     }
 
 
 def get_list_of_guides() -> dict[str, Any]:
-    """Get list of Qiskit guides and best practices with URL paths."""
+    """Get list of Qiskit guides and best practices with descriptions and URL paths."""
     return {
         "status": "success",
-        "guides": [{"name": name, "url_path": f"guides/{name}"} for name in AVAILABLE_GUIDES],
+        "guides": [
+            {"name": name, "description": desc, "url_path": f"guides/{name}"}
+            for name, desc in AVAILABLE_GUIDES.items()
+        ],
     }
 
 

--- a/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/data_fetcher.py
+++ b/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/data_fetcher.py
@@ -82,6 +82,9 @@ def _truncate_content(content: str, max_length: int = 20000, offset: int = 0) ->
 
     total_length = len(content)
 
+    # Clamp offset to content length
+    offset = min(offset, total_length)
+
     if max_length <= 0:
         return {
             "content": content[offset:] if offset > 0 else content,
@@ -255,6 +258,9 @@ async def get_page_docs(url: str, max_length: int = 20000, offset: int = 0) -> d
     }
 
 
+_VALID_SCOPES = {"all", "documentation", "api", "learning", "tutorials"}
+
+
 async def search_qiskit_docs(query: str, scope: str = "all") -> dict[str, Any]:
     """Search Qiskit documentation for relevant results.
 
@@ -266,6 +272,14 @@ async def search_qiskit_docs(query: str, scope: str = "all") -> dict[str, Any]:
     Returns:
         Search results with matching entries, total count, and metadata
     """
+    if scope not in _VALID_SCOPES:
+        return {
+            "status": "error",
+            "message": (
+                f"Invalid scope '{scope}'. Valid values: {', '.join(sorted(_VALID_SCOPES))}."
+            ),
+        }
+
     url = f"{BASE_URL}{SEARCH_PATH}?query={quote(query)}&module={quote(scope)}"
     logger.info(f"Searching docs for '{query}' in scope '{scope}'")
 

--- a/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/data_fetcher.py
+++ b/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/data_fetcher.py
@@ -10,12 +10,11 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-import difflib
 import logging
 import re
 from datetime import datetime, timezone
 from typing import Any
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 import html2text
 import httpx
@@ -34,29 +33,24 @@ from qiskit_docs_mcp_server.constants import (
 
 logger = logging.getLogger(__name__)
 
+# Allowed hostname for URL validation
+_ALLOWED_HOST = "quantum.cloud.ibm.com"
 
-def _find_similar(query: str, available: list[str], cutoff: float = 0.6) -> list[str]:
-    """
-    Find similar strings using difflib.get_close_matches.
+
+def _strip_html_tags(text: str) -> str:
+    """Strip HTML tags from a string.
 
     Args:
-        query: The query string to match
-        available: List of available options to search
-        cutoff: Similarity threshold (0.0-1.0), default 0.6
+        text: String potentially containing HTML tags
 
     Returns:
-        List of similar strings, sorted by similarity (highest first)
+        String with all HTML tags removed
     """
-    if not query or not available:
-        return []
-
-    matches = difflib.get_close_matches(query, available, n=3, cutoff=cutoff)
-    return matches
+    return re.sub(r"<[^>]+>", "", text)
 
 
 def convert_html_to_markdown(html: str) -> str:
-    """
-    Convert HTML content to Markdown format.
+    """Convert HTML content to Markdown format.
 
     Args:
         html: HTML content string
@@ -71,9 +65,39 @@ def convert_html_to_markdown(html: str) -> str:
     return h.handle(html)
 
 
-async def fetch_text(url: str) -> str | None:
+def _resolve_url(url: str) -> str:
+    """Resolve a URL or relative path to a full documentation URL.
+
+    Args:
+        url: Full URL or path relative to docs base
+            (e.g., 'guides/transpile' or 'api/qiskit/circuit')
+
+    Returns:
+        Full resolved URL
+
+    Raises:
+        ValueError: If the URL is outside the allowed documentation domain
     """
-    Fetch text content from a URL using httpx.
+    # If it's already a full URL, validate the domain
+    parsed = urlparse(url)
+    if parsed.scheme and parsed.netloc:
+        if parsed.netloc != _ALLOWED_HOST:
+            msg = (
+                f"URL domain '{parsed.netloc}' is not allowed. "
+                f"Only URLs from '{_ALLOWED_HOST}' are supported."
+            )
+            raise ValueError(msg)
+        return url
+
+    # Relative path — resolve against the docs base
+    # Strip leading slash if present
+    path = url.lstrip("/")
+    base = QISKIT_DOCS_BASE.rstrip("/")
+    return f"{base}/{path}"
+
+
+async def fetch_text(url: str) -> str | None:
+    """Fetch text content from a URL using httpx.
 
     Args:
         url: The URL to fetch
@@ -95,8 +119,7 @@ async def fetch_text(url: str) -> str | None:
 
 
 async def fetch_text_json(url: str) -> list[dict[str, Any]] | None:
-    """
-    Fetch JSON content from a URL using httpx.
+    """Fetch JSON content from a URL using httpx.
 
     Args:
         url: The URL to fetch
@@ -117,109 +140,71 @@ async def fetch_text_json(url: str) -> list[dict[str, Any]] | None:
         return None
 
 
-async def get_component_docs(component: str) -> dict[str, Any]:
-    """
-    Fetch documentation for a Qiskit SDK module and convert to Markdown.
+async def get_page_docs(url: str) -> dict[str, Any]:
+    """Fetch any Qiskit documentation page and return as markdown.
+
+    Accepts full URLs or relative paths. Validates that the URL is within
+    the allowed documentation domain.
 
     Args:
-        component: Module name (e.g., 'circuit', 'primitives', 'transpiler')
+        url: Full URL or relative path (e.g., 'guides/transpile',
+            'api/qiskit/circuit', 'api/qiskit/qiskit.circuit.QuantumCircuit')
 
     Returns:
-        The documentation content in Markdown format or error status
+        Documentation content in markdown with metadata, or error status
     """
-    if component not in AVAILABLE_MODULES:
-        suggestions = _find_similar(component, AVAILABLE_MODULES)
-        error_response = {
-            "status": "error",
-            "message": f"Module '{component}' not found.",
-            "available_modules": AVAILABLE_MODULES,
-        }
-        if suggestions:
-            error_response["suggestions"] = suggestions
-        return error_response
-
-    url = f"{QISKIT_DOCS_BASE}api/qiskit/{component}"
-    logger.info(f"Fetching component docs for {component} from {url}")
-    html = await fetch_text(url)
-    docs = convert_html_to_markdown(html) if html else None
-
-    if docs is None:
+    try:
+        resolved_url = _resolve_url(url)
+    except ValueError as e:
         return {
             "status": "error",
-            "message": f"Failed to fetch documentation for component '{component}'.",
+            "message": str(e),
         }
+
+    logger.info(f"Fetching page docs from {resolved_url}")
+    html = await fetch_text(resolved_url)
+
+    if html is None:
+        return {
+            "status": "error",
+            "message": (
+                f"Failed to fetch '{url}'. The page may not exist. "
+                "Try using search_docs_tool to find the correct URL."
+            ),
+            "metadata": {
+                "url": resolved_url,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            },
+        }
+
+    docs = convert_html_to_markdown(html)
 
     return {
         "status": "success",
-        "module": component,
+        "url": resolved_url,
         "documentation": docs,
         "metadata": {
-            "url": url,
+            "url": resolved_url,
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "content_type": "markdown",
-            "content_length": len(docs) if docs else 0,
+            "content_length": len(docs),
         },
     }
 
 
-async def get_guide_docs(guide: str) -> dict[str, Any]:
-    """
-    Fetch documentation for a Qiskit guide or best practice and convert to Markdown.
+async def search_qiskit_docs(query: str, scope: str = "all") -> dict[str, Any]:
+    """Search Qiskit documentation for relevant results.
 
     Args:
-        guide: Guide name (e.g., 'quick-start', 'transpile', 'configure-error-mitigation')
-
-    Returns:
-        The documentation content in Markdown format or error status
-    """
-    if guide not in AVAILABLE_GUIDES:
-        suggestions = _find_similar(guide, AVAILABLE_GUIDES)
-        error_response = {
-            "status": "error",
-            "message": f"Guide '{guide}' not found.",
-            "available_guides": AVAILABLE_GUIDES,
-        }
-        if suggestions:
-            error_response["suggestions"] = suggestions
-        return error_response
-
-    url = f"{QISKIT_DOCS_BASE}guides/{guide}"
-    logger.info(f"Fetching style docs for {guide} from {url}")
-    html = await fetch_text(url)
-    docs = convert_html_to_markdown(html) if html else None
-
-    if docs is None:
-        return {
-            "status": "error",
-            "message": f"Failed to fetch documentation for guide '{guide}'.",
-        }
-
-    return {
-        "status": "success",
-        "guide": guide,
-        "documentation": docs,
-        "metadata": {
-            "url": url,
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            "content_type": "markdown",
-            "content_length": len(docs) if docs else 0,
-        },
-    }
-
-
-async def search_qiskit_docs(query: str, module: str = "documentation") -> dict[str, Any]:
-    """
-    Search Qiskit documentation for relevant results.
-
-    Args:
-        query: Search query string (e.g., 'circuit', 'error mitigation')
-        module: Search scope (e.g., 'documentation', 'API')
+        query: Search query string
+        scope: Search scope filter. Valid values (case-sensitive):
+            'all', 'documentation', 'api', 'learning', 'tutorials'
 
     Returns:
         Search results with matching entries, total count, and metadata
     """
-    url = f"{BASE_URL}{SEARCH_PATH}?query={quote(query)}&module={quote(module)}"
-    logger.info(f"Searching docs for '{query}' in module '{module}'")
+    url = f"{BASE_URL}{SEARCH_PATH}?query={quote(query)}&module={quote(scope)}"
+    logger.info(f"Searching docs for '{query}' in scope '{scope}'")
 
     results = await fetch_text_json(url)
 
@@ -233,10 +218,17 @@ async def search_qiskit_docs(query: str, module: str = "documentation") -> dict[
             },
         }
 
+    # Strip HTML tags from search result fields
+    for result_item in results:
+        if "title" in result_item:
+            result_item["title"] = _strip_html_tags(result_item["title"])
+        if "text" in result_item:
+            result_item["text"] = _strip_html_tags(result_item["text"])
+
     return {
         "status": "success",
         "query": query,
-        "module": module,
+        "scope": scope,
         "results": results,
         "total_results": len(results),
         "metadata": {
@@ -248,8 +240,7 @@ async def search_qiskit_docs(query: str, module: str = "documentation") -> dict[
 
 
 async def lookup_error_code(code: str) -> dict[str, Any]:
-    """
-    Look up a Qiskit error code and return its message and solution.
+    """Look up a Qiskit error code and return its message and solution.
 
     Args:
         code: Error code string (e.g., '1002', '7001')
@@ -260,7 +251,9 @@ async def lookup_error_code(code: str) -> dict[str, Any]:
     if not re.fullmatch(r"\d{4}", code):
         return {
             "status": "error",
-            "message": f"Invalid error code format: '{code}'. Expected a 4-digit code (e.g., '1002').",
+            "message": (
+                f"Invalid error code format: '{code}'. Expected a 4-digit code (e.g., '1002')."
+            ),
         }
 
     url = f"{QISKIT_DOCS_BASE}errors"
@@ -277,12 +270,10 @@ async def lookup_error_code(code: str) -> dict[str, Any]:
     docs = convert_html_to_markdown(html)
 
     # Search for the error code in the markdown content
-    # Error codes appear as table rows: | code | message | solution |
     lines = docs.split("\n")
     matching_lines: list[str] = []
     for i, line in enumerate(lines):
         if re.search(rf"\b{code}\b", line):
-            # Grab surrounding context (table header + matching row)
             start = max(0, i - 2)
             end = min(len(lines), i + 3)
             matching_lines.extend(lines[start:end])
@@ -311,63 +302,29 @@ async def lookup_error_code(code: str) -> dict[str, Any]:
 
 
 def get_list_of_modules() -> dict[str, Any]:
-    """Get list of all Qiskit SDK modules."""
-    return {"status": "success", "modules": AVAILABLE_MODULES}
-
-
-async def get_addon_docs(addon: str) -> dict[str, Any]:
-    """
-    Fetch documentation for a Qiskit addon module and convert to Markdown.
-
-    Args:
-        addon: Addon name (e.g., 'sqd', 'cutting', 'mpf')
-
-    Returns:
-        The documentation content in Markdown format or error status
-    """
-    if addon not in AVAILABLE_ADDONS:
-        suggestions = _find_similar(addon, AVAILABLE_ADDONS)
-        error_response = {
-            "status": "error",
-            "message": f"Addon '{addon}' not found.",
-            "available_addons": AVAILABLE_ADDONS,
-        }
-        if suggestions:
-            error_response["suggestions"] = suggestions
-        return error_response
-
-    url = f"{QISKIT_DOCS_BASE}api/qiskit-addon-{addon}"
-    logger.info(f"Fetching addon docs for {addon} from {url}")
-    html = await fetch_text(url)
-    docs = convert_html_to_markdown(html) if html else None
-
-    if docs is None:
-        return {
-            "status": "error",
-            "message": f"Failed to fetch documentation for addon '{addon}'.",
-        }
-
+    """Get list of all Qiskit SDK modules with URL paths."""
     return {
         "status": "success",
-        "addon": addon,
-        "documentation": docs,
-        "metadata": {
-            "url": url,
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            "content_type": "markdown",
-            "content_length": len(docs) if docs else 0,
-        },
+        "modules": [{"name": name, "url_path": f"api/qiskit/{name}"} for name in AVAILABLE_MODULES],
     }
 
 
 def get_list_of_addons() -> dict[str, Any]:
-    """Get list of all Qiskit addon modules."""
-    return {"status": "success", "addons": AVAILABLE_ADDONS}
+    """Get list of all Qiskit addon modules with URL paths."""
+    return {
+        "status": "success",
+        "addons": [
+            {"name": name, "url_path": f"api/qiskit-addon-{name}"} for name in AVAILABLE_ADDONS
+        ],
+    }
 
 
 def get_list_of_guides() -> dict[str, Any]:
-    """Get list of Qiskit guides and best practices."""
-    return {"status": "success", "guides": AVAILABLE_GUIDES}
+    """Get list of Qiskit guides and best practices with URL paths."""
+    return {
+        "status": "success",
+        "guides": [{"name": name, "url_path": f"guides/{name}"} for name in AVAILABLE_GUIDES],
+    }
 
 
 def get_list_of_error_code_categories() -> dict[str, Any]:

--- a/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/server.py
+++ b/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/server.py
@@ -75,11 +75,19 @@ async def search_docs_tool(query: str, scope: str = "all") -> dict[str, Any]:
 
 
 @mcp.tool()
-async def get_page_tool(url: str) -> dict[str, Any]:
+async def get_page_tool(
+    url: str,
+    max_length: int = 20000,
+    offset: int = 0,
+) -> dict[str, Any]:
     """Fetch a Qiskit documentation page and return its content as markdown.
 
     Accepts any URL from the Qiskit documentation site. Use search_docs_tool
     first to find the right page, or use URLs from the resource lists.
+
+    Returns documentation in markdown format with pagination support.
+    Default max_length is 20000 chars. Set max_length=0 for unlimited.
+    Use offset to retrieve subsequent pages when has_more is true.
 
     This tool can fetch ANY page in the Qiskit documentation, including:
     - SDK module API references (e.g., 'api/qiskit/circuit')
@@ -92,12 +100,15 @@ async def get_page_tool(url: str) -> dict[str, Any]:
         url: Documentation page URL. Accepts:
             - Full URL: 'https://quantum.cloud.ibm.com/docs/guides/transpile'
             - Relative path: 'guides/transpile', 'api/qiskit/circuit'
+        max_length: Maximum characters to return (default: 20000, 0 for unlimited)
+        offset: Character offset for pagination (default: 0)
 
     Returns:
-        Page content in markdown format with metadata, or error with
-        suggestion to use search_docs_tool if the page is not found.
+        Page content in markdown format with pagination metadata
+        (has_more, next_offset, total_length), or error with suggestion
+        to use search_docs_tool if the page is not found.
     """
-    return await get_page_docs(url)
+    return await get_page_docs(url, max_length=max_length, offset=offset)
 
 
 @mcp.tool()

--- a/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/server.py
+++ b/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/server.py
@@ -23,13 +23,11 @@ from typing import Any
 from fastmcp import FastMCP
 
 from qiskit_docs_mcp_server.data_fetcher import (
-    get_addon_docs,
-    get_component_docs,
-    get_guide_docs,
     get_list_of_addons,
     get_list_of_error_code_categories,
     get_list_of_guides,
     get_list_of_modules,
+    get_page_docs,
     lookup_error_code,
     search_qiskit_docs,
 )
@@ -52,72 +50,82 @@ logger.info("Qiskit Documentation MCP Server initialized")
 
 
 @mcp.tool()
-async def get_sdk_module_docs_tool(module: str) -> dict[str, Any]:
-    """
-    Get documentation for a Qiskit SDK module.
+async def search_docs_tool(query: str, scope: str = "all") -> dict[str, Any]:
+    """Search across the entire Qiskit documentation for relevant content.
+
+    Use this as the primary entry point to discover documentation pages.
+    Returns ranked results with titles, URLs, sections, and text snippets.
+    Use get_page_tool to fetch the full content of any result URL.
 
     Args:
-        module: Module name (e.g., 'circuit', 'primitives', 'transpiler', 'quantum_info')
+        query: Search query string (e.g., 'error mitigation', 'QuantumCircuit',
+            'transpiler optimization'). More specific queries yield better results.
+        scope: Search scope filter (case-sensitive). Valid values:
+            'all' — Search everything (default)
+            'documentation' — Guides and general docs
+            'api' — API reference pages only
+            'learning' — Learning resources and tutorials
+            'tutorials' — Tutorial content only
 
     Returns:
-        Module documentation including API reference and usage examples.
+        List of matching documentation entries with URLs, titles, sections,
+        and text snippets. Use the URLs with get_page_tool to fetch full content.
     """
-    return await get_component_docs(module)
+    return await search_qiskit_docs(query, scope)
 
 
 @mcp.tool()
-async def get_addon_docs_tool(addon: str) -> dict[str, Any]:
-    """
-    Get documentation for a Qiskit addon module.
+async def get_page_tool(url: str) -> dict[str, Any]:
+    """Fetch a Qiskit documentation page and return its content as markdown.
+
+    Accepts any URL from the Qiskit documentation site. Use search_docs_tool
+    first to find the right page, or use URLs from the resource lists.
+
+    This tool can fetch ANY page in the Qiskit documentation, including:
+    - SDK module API references (e.g., 'api/qiskit/circuit')
+    - Individual class pages (e.g., 'api/qiskit/qiskit.circuit.QuantumCircuit')
+    - Addon documentation (e.g., 'api/qiskit-addon-sqd')
+    - Implementation guides (e.g., 'guides/transpile')
+    - Any other documentation page
 
     Args:
-        addon: Addon name (e.g., 'sqd', 'cutting', 'mpf', 'obp', 'aqc-tensor')
+        url: Documentation page URL. Accepts:
+            - Full URL: 'https://quantum.cloud.ibm.com/docs/guides/transpile'
+            - Relative path: 'guides/transpile', 'api/qiskit/circuit'
 
     Returns:
-        Addon API documentation including classes, methods, and usage examples.
+        Page content in markdown format with metadata, or error with
+        suggestion to use search_docs_tool if the page is not found.
     """
-    return await get_addon_docs(addon)
-
-
-@mcp.tool()
-async def get_guide_tool(guide: str) -> dict[str, Any]:
-    """
-    Get a Qiskit guide or best practice documentation.
-
-    Args:
-        guide: Guide name (e.g., 'quick-start', 'transpile', 'configure-error-mitigation', 'dynamic-circuits')
-
-    Returns:
-        Complete guide documentation with best practices and implementation patterns.
-    """
-    return await get_guide_docs(guide)
-
-
-@mcp.tool()
-async def search_docs_tool(query: str, module: str = "documentation") -> dict[str, Any]:
-    """
-    Search Qiskit documentation for relevant modules, addons, and guides.
-
-    Args:
-        query: Search query (e.g., 'optimization', 'circuit', 'error')
-        module: Search module (e.g. 'documentation', 'API' etc)
-
-    Returns:
-        List of matching documentation entries with URLs and types.
-    """
-    return await search_qiskit_docs(query, module)
+    return await get_page_docs(url)
 
 
 @mcp.tool()
 async def lookup_error_code_tool(code: str) -> dict[str, Any]:
-    """
-    Look up a Qiskit/IBM Quantum error code to get its message and solution.
+    """Look up a Qiskit or IBM Quantum error code to get its description and solution.
+
+    Use this when a user encounters a numeric error code from Qiskit or
+    IBM Quantum services. Returns the error message and suggested fix.
+    Read the qiskit-docs://error-codes resource for error code categories.
+
+    Error code ranges:
+        1XXX: Validation, transpilation, backend, authorization, job management
+        2XXX: Backend configuration, booking, data retrieval
+        3XXX: Job handling, authentication, analytics
+        4XXX: Session management and job limits
+        5XXX: Job timeout and cancellation
+        6XXX: Shot limits, compiler input, control system
+        7XXX: Instruction and basis gate compatibility
+        8XXX: Pulse and channel configuration
+        9XXX: Hardware loading and internal errors
 
     Args:
-        code: 4-digit error code (e.g., '1002', '7001', '8004')
+        code: 4-digit numeric error code as a string (e.g., '1002', '7001').
+            Must be exactly 4 digits.
 
     Returns:
-        Error code details including message and suggested solution.
+        Error code details including message, solution, and link to the
+        error registry. Returns error if code format is invalid or not found.
     """
     return await lookup_error_code(code)
 
@@ -130,19 +138,33 @@ async def lookup_error_code_tool(code: str) -> dict[str, Any]:
 
 @mcp.resource("qiskit-docs://modules", mime_type="application/json")
 def modules_resource() -> dict[str, Any]:
-    """Get list of all Qiskit SDK modules."""
+    """Get list of all Qiskit SDK modules with URL paths.
+
+    Returns curated list of common SDK modules. Use get_page_tool with
+    'api/qiskit/{module}' to fetch documentation, or search_docs_tool
+    to discover any module page.
+    """
     return get_list_of_modules()
 
 
 @mcp.resource("qiskit-docs://addons", mime_type="application/json")
 def addons_resource() -> dict[str, Any]:
-    """Get list of all Qiskit addon modules."""
+    """Get list of Qiskit addon packages with URL paths.
+
+    Returns curated list of addon packages. Use get_page_tool with
+    'api/qiskit-addon-{name}' to fetch documentation.
+    """
     return get_list_of_addons()
 
 
 @mcp.resource("qiskit-docs://guides", mime_type="application/json")
 def guides_resource() -> dict[str, Any]:
-    """Get list of Qiskit guides and best practices."""
+    """Get list of Qiskit implementation guides with URL paths.
+
+    Returns curated list of common guides. Use get_page_tool with
+    'guides/{name}' to fetch documentation, or search_docs_tool to
+    discover any guide.
+    """
     return get_list_of_guides()
 
 

--- a/qiskit-docs-mcp-server/tests/test_data_fetcher.py
+++ b/qiskit-docs-mcp-server/tests/test_data_fetcher.py
@@ -20,13 +20,17 @@ from qiskit_docs_mcp_server.constants import (
     AVAILABLE_ADDONS,
     AVAILABLE_GUIDES,
     AVAILABLE_MODULES,
+    CACHE_TTL,
     HTTP_TIMEOUT,
     _get_env_float,
 )
 from qiskit_docs_mcp_server.data_fetcher import (
+    _json_cache,
     _resolve_url,
     _strip_html_tags,
+    _text_cache,
     _truncate_content,
+    _TTLCache,
     convert_html_to_markdown,
     fetch_text,
     fetch_text_json,
@@ -43,44 +47,50 @@ from qiskit_docs_mcp_server.data_fetcher import (
 class TestFetchText:
     """Test fetch_text function."""
 
-    @patch("qiskit_docs_mcp_server.data_fetcher.httpx.AsyncClient")
-    async def test_fetch_text_success(self, mock_client_class):
+    def setup_method(self):
+        """Clear cache before each test."""
+        _text_cache.clear()
+        _json_cache.clear()
+
+    @patch("qiskit_docs_mcp_server.data_fetcher._get_http_client")
+    async def test_fetch_text_success(self, mock_get_client):
         """Test successful text fetch."""
         mock_response = MagicMock()
         mock_response.text = "Sample documentation"
+        mock_response.raise_for_status = MagicMock()
         mock_client = AsyncMock()
         mock_client.get.return_value = mock_response
-        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_get_client.return_value = mock_client
 
         result = await fetch_text("https://example.com")
         assert result == "Sample documentation"
 
-    @patch("qiskit_docs_mcp_server.data_fetcher.httpx.AsyncClient")
-    async def test_fetch_text_http_error(self, mock_client_class):
+    @patch("qiskit_docs_mcp_server.data_fetcher._get_http_client")
+    async def test_fetch_text_http_error(self, mock_get_client):
         """Test fetch_text with HTTP error."""
         mock_client = AsyncMock()
         mock_client.get.side_effect = httpx.HTTPError("Connection failed")
-        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_get_client.return_value = mock_client
 
         result = await fetch_text("https://example.com")
         assert result is None
 
-    @patch("qiskit_docs_mcp_server.data_fetcher.httpx.AsyncClient")
-    async def test_fetch_text_generic_exception(self, mock_client_class):
+    @patch("qiskit_docs_mcp_server.data_fetcher._get_http_client")
+    async def test_fetch_text_generic_exception(self, mock_get_client):
         """Test fetch_text with generic exception."""
         mock_client = AsyncMock()
         mock_client.get.side_effect = Exception("Unexpected error")
-        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_get_client.return_value = mock_client
 
         result = await fetch_text("https://example.com")
         assert result is None
 
-    @patch("qiskit_docs_mcp_server.data_fetcher.httpx.AsyncClient")
-    async def test_fetch_text_timeout(self, mock_client_class):
+    @patch("qiskit_docs_mcp_server.data_fetcher._get_http_client")
+    async def test_fetch_text_timeout(self, mock_get_client):
         """Test fetch_text with timeout."""
         mock_client = AsyncMock()
         mock_client.get.side_effect = httpx.TimeoutException("Request timed out")
-        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_get_client.return_value = mock_client
 
         result = await fetch_text("https://example.com")
         assert result is None
@@ -89,46 +99,53 @@ class TestFetchText:
 class TestFetchTextJson:
     """Test fetch_text_json function."""
 
-    @patch("qiskit_docs_mcp_server.data_fetcher.httpx.AsyncClient")
-    async def test_fetch_text_json_success(self, mock_client_class):
+    def setup_method(self):
+        """Clear cache before each test."""
+        _text_cache.clear()
+        _json_cache.clear()
+
+    @patch("qiskit_docs_mcp_server.data_fetcher._get_http_client")
+    async def test_fetch_text_json_success(self, mock_get_client):
         """Test successful JSON fetch."""
         mock_response = MagicMock()
         mock_response.json.return_value = [{"key": "value"}]
+        mock_response.raise_for_status = MagicMock()
         mock_client = AsyncMock()
         mock_client.get.return_value = mock_response
-        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_get_client.return_value = mock_client
 
         result = await fetch_text_json("https://example.com/api")
         assert result == [{"key": "value"}]
 
-    @patch("qiskit_docs_mcp_server.data_fetcher.httpx.AsyncClient")
-    async def test_fetch_text_json_http_error(self, mock_client_class):
+    @patch("qiskit_docs_mcp_server.data_fetcher._get_http_client")
+    async def test_fetch_text_json_http_error(self, mock_get_client):
         """Test fetch_text_json with HTTP error."""
         mock_client = AsyncMock()
         mock_client.get.side_effect = httpx.HTTPError("Connection failed")
-        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_get_client.return_value = mock_client
 
         result = await fetch_text_json("https://example.com/api")
         assert result is None
 
-    @patch("qiskit_docs_mcp_server.data_fetcher.httpx.AsyncClient")
-    async def test_fetch_text_json_generic_exception(self, mock_client_class):
+    @patch("qiskit_docs_mcp_server.data_fetcher._get_http_client")
+    async def test_fetch_text_json_generic_exception(self, mock_get_client):
         """Test fetch_text_json with generic exception."""
         mock_client = AsyncMock()
         mock_client.get.side_effect = Exception("Unexpected error")
-        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_get_client.return_value = mock_client
 
         result = await fetch_text_json("https://example.com/api")
         assert result is None
 
-    @patch("qiskit_docs_mcp_server.data_fetcher.httpx.AsyncClient")
-    async def test_fetch_text_json_returns_list(self, mock_client_class):
+    @patch("qiskit_docs_mcp_server.data_fetcher._get_http_client")
+    async def test_fetch_text_json_returns_list(self, mock_get_client):
         """Test that fetch_text_json returns list."""
         mock_response = MagicMock()
         mock_response.json.return_value = [{"name": "test"}]
+        mock_response.raise_for_status = MagicMock()
         mock_client = AsyncMock()
         mock_client.get.return_value = mock_response
-        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_get_client.return_value = mock_client
 
         result = await fetch_text_json("https://example.com")
         assert isinstance(result, list)
@@ -635,3 +652,111 @@ class TestEnvironmentConfiguration:
         """Test that HTTP_TIMEOUT has a reasonable default."""
         assert HTTP_TIMEOUT > 0
         assert HTTP_TIMEOUT <= 30.0
+
+    def test_cache_ttl_default(self):
+        """Test that CACHE_TTL has a reasonable default."""
+        assert CACHE_TTL > 0
+        assert CACHE_TTL <= 86400  # At most 24 hours
+
+    @patch("qiskit_docs_mcp_server.data_fetcher.httpx.AsyncClient")
+    def test_fetch_text_uses_http_timeout(self, mock_client_class):
+        """Test that _get_http_client creates client with HTTP_TIMEOUT."""
+        import qiskit_docs_mcp_server.data_fetcher as df
+        from qiskit_docs_mcp_server.data_fetcher import _get_http_client
+
+        # Force creation of a new client
+        original_holder = df._client_holder.copy()
+        df._client_holder.clear()
+        try:
+            _get_http_client()
+            mock_client_class.assert_called_once()
+            call_kwargs = mock_client_class.call_args[1]
+            assert "timeout" in call_kwargs
+            assert call_kwargs["timeout"] == HTTP_TIMEOUT
+            assert call_kwargs["follow_redirects"] is True
+        finally:
+            df._client_holder.clear()
+            df._client_holder.update(original_holder)
+
+
+class TestCaching:
+    """Test in-memory caching functionality."""
+
+    def setup_method(self):
+        """Clear caches before each test."""
+        _text_cache.clear()
+        _json_cache.clear()
+
+    @patch("qiskit_docs_mcp_server.data_fetcher._get_http_client")
+    async def test_fetch_text_caches_result(self, mock_get_client):
+        """Test that fetch_text caches successful results."""
+        mock_response = MagicMock()
+        mock_response.text = "Cached content"
+        mock_response.raise_for_status = MagicMock()
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_get_client.return_value = mock_client
+
+        # First call — should hit network
+        result1 = await fetch_text("https://example.com/page")
+        assert result1 == "Cached content"
+        assert mock_client.get.call_count == 1
+
+        # Second call — should use cache
+        result2 = await fetch_text("https://example.com/page")
+        assert result2 == "Cached content"
+        assert mock_client.get.call_count == 1  # No additional network call
+
+    @patch("qiskit_docs_mcp_server.data_fetcher._get_http_client")
+    async def test_fetch_text_json_caches_result(self, mock_get_client):
+        """Test that fetch_text_json caches successful results."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = [{"key": "value"}]
+        mock_response.raise_for_status = MagicMock()
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_get_client.return_value = mock_client
+
+        result1 = await fetch_text_json("https://example.com/api")
+        assert result1 == [{"key": "value"}]
+        assert mock_client.get.call_count == 1
+
+        result2 = await fetch_text_json("https://example.com/api")
+        assert result2 == [{"key": "value"}]
+        assert mock_client.get.call_count == 1
+
+    @patch("qiskit_docs_mcp_server.data_fetcher._get_http_client")
+    async def test_fetch_text_does_not_cache_errors(self, mock_get_client):
+        """Test that failed fetches are not cached."""
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = httpx.HTTPError("Connection failed")
+        mock_get_client.return_value = mock_client
+
+        result1 = await fetch_text("https://example.com/fail")
+        assert result1 is None
+
+        # Should try network again (not serve None from cache)
+        result2 = await fetch_text("https://example.com/fail")
+        assert result2 is None
+        assert mock_client.get.call_count == 2
+
+    def test_cache_clear(self):
+        """Test cache clear functionality."""
+        _text_cache.set("key", "value")
+        assert _text_cache.get("key") == "value"
+        _text_cache.clear()
+        assert _text_cache.get("key") is None
+
+    def test_cache_evicts_oldest_at_max_size(self):
+        """Test that cache evicts the oldest entry when at capacity."""
+        cache = _TTLCache(ttl=3600.0, max_size=2)
+        cache.set("a", 1)
+        cache.set("b", 2)
+        assert cache.get("a") == 1
+        assert cache.get("b") == 2
+
+        # Adding a third entry should evict the oldest ("a")
+        cache.set("c", 3)
+        assert cache.get("a") is None
+        assert cache.get("b") == 2
+        assert cache.get("c") == 3

--- a/qiskit-docs-mcp-server/tests/test_data_fetcher.py
+++ b/qiskit-docs-mcp-server/tests/test_data_fetcher.py
@@ -15,8 +15,10 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
+import pytest
 from qiskit_docs_mcp_server.constants import (
     AVAILABLE_ADDONS,
+    AVAILABLE_GUIDES,
     AVAILABLE_MODULES,
     HTTP_TIMEOUT,
     _get_env_float,
@@ -24,6 +26,7 @@ from qiskit_docs_mcp_server.constants import (
 from qiskit_docs_mcp_server.data_fetcher import (
     _resolve_url,
     _strip_html_tags,
+    _truncate_content,
     convert_html_to_markdown,
     fetch_text,
     fetch_text_json,
@@ -161,8 +164,6 @@ class TestResolveUrl:
 
     def test_full_url_disallowed_domain(self):
         """Test that URLs with disallowed domains raise ValueError."""
-        import pytest
-
         with pytest.raises(ValueError, match="not allowed"):
             _resolve_url("https://evil.com/malicious")
 
@@ -170,6 +171,11 @@ class TestResolveUrl:
         """Test resolving an addon path."""
         url = _resolve_url("api/qiskit-addon-sqd")
         assert url == "https://quantum.cloud.ibm.com/docs/api/qiskit-addon-sqd"
+
+    def test_resolve_empty_string(self):
+        """Test resolving an empty string returns base URL."""
+        url = _resolve_url("")
+        assert url == "https://quantum.cloud.ibm.com/docs/"
 
 
 class TestGetPageDocs:
@@ -214,6 +220,86 @@ class TestGetPageDocs:
         assert "metadata" in result
         assert "url" in result["metadata"]
         assert "timestamp" in result["metadata"]
+
+    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
+    async def test_get_page_pagination_has_more(self, mock_fetch):
+        """Test that get_page_docs returns pagination fields."""
+        mock_fetch.return_value = "<p>" + "x" * 50000 + "</p>"
+        result = await get_page_docs("api/qiskit/circuit", max_length=1000)
+        assert result["status"] == "success"
+        assert result["has_more"] is True
+        assert result["next_offset"] is not None
+        assert result["total_length"] > 1000
+
+    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
+    async def test_get_page_pagination_with_offset(self, mock_fetch):
+        """Test pagination with offset retrieves subsequent content."""
+        mock_fetch.return_value = "<p>" + "A" * 100 + "</p>"
+        result = await get_page_docs("api/qiskit/circuit", max_length=50, offset=10)
+        assert result["status"] == "success"
+        assert "has_more" in result
+
+    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
+    async def test_get_page_unlimited_length(self, mock_fetch):
+        """Test max_length=0 returns all content without truncation."""
+        mock_fetch.return_value = "<p>" + "y" * 50000 + "</p>"
+        result = await get_page_docs("api/qiskit/circuit", max_length=0)
+        assert result["status"] == "success"
+        assert result["has_more"] is False
+
+
+class TestTruncateContent:
+    """Test _truncate_content function."""
+
+    def test_short_content_no_truncation(self):
+        """Test that short content is not truncated."""
+        result = _truncate_content("hello world", max_length=100)
+        assert result["content"] == "hello world"
+        assert result["has_more"] is False
+        assert result["next_offset"] is None
+
+    def test_long_content_truncated(self):
+        """Test that content exceeding max_length is truncated."""
+        content = "a" * 200
+        result = _truncate_content(content, max_length=100)
+        assert len(result["content"]) <= 100
+        assert result["has_more"] is True
+        assert result["next_offset"] is not None
+        assert result["total_length"] == 200
+
+    def test_offset_skips_content(self):
+        """Test that offset skips the beginning of content."""
+        content = "0123456789"
+        result = _truncate_content(content, max_length=100, offset=5)
+        assert result["content"] == "56789"
+        assert result["has_more"] is False
+
+    def test_unlimited_returns_all(self):
+        """Test max_length=0 returns all content."""
+        content = "a" * 50000
+        result = _truncate_content(content, max_length=0)
+        assert result["content"] == content
+        assert result["has_more"] is False
+
+    def test_negative_offset_clamped_to_zero(self):
+        """Test that negative offset is clamped to 0."""
+        result = _truncate_content("hello", max_length=100, offset=-5)
+        assert result["content"] == "hello"
+        assert result["offset"] == 0
+
+    def test_negative_max_length_treated_as_unlimited(self):
+        """Test that negative max_length is treated as unlimited (clamped to 0)."""
+        content = "a" * 500
+        result = _truncate_content(content, max_length=-10)
+        assert result["content"] == content
+        assert result["has_more"] is False
+
+    def test_truncation_snaps_to_line_boundary(self):
+        """Test that truncation snaps to a nearby newline boundary."""
+        lines = "\n".join(["line " + str(i) for i in range(50)])
+        result = _truncate_content(lines, max_length=100)
+        assert result["content"].endswith("\n")
+        assert result["has_more"] is True
 
 
 class TestStripHtmlTags:
@@ -385,9 +471,10 @@ class TestListHelpers:
         assert "modules" in result
         assert isinstance(result["modules"], list)
         assert len(result["modules"]) > 0
-        # Check structure includes url_path
+        # Check structure includes name, description, url_path
         first = result["modules"][0]
         assert "name" in first
+        assert "description" in first
         assert "url_path" in first
         assert first["url_path"].startswith("api/qiskit/")
 
@@ -399,6 +486,7 @@ class TestListHelpers:
         assert len(result["addons"]) > 0
         first = result["addons"][0]
         assert "name" in first
+        assert "description" in first
         assert "url_path" in first
         assert "qiskit-addon-" in first["url_path"]
 
@@ -410,6 +498,7 @@ class TestListHelpers:
         assert len(result["guides"]) > 0
         first = result["guides"][0]
         assert "name" in first
+        assert "description" in first
         assert "url_path" in first
         assert first["url_path"].startswith("guides/")
 
@@ -433,9 +522,37 @@ class TestDocFetcherConstants:
         """Test that AVAILABLE_MODULES contains circuit."""
         assert "circuit" in AVAILABLE_MODULES
 
+    def test_qiskit_modules_are_dict_with_descriptions(self):
+        """Test that AVAILABLE_MODULES values are description strings."""
+        assert isinstance(AVAILABLE_MODULES, dict)
+        for key, value in AVAILABLE_MODULES.items():
+            assert isinstance(key, str)
+            assert isinstance(value, str)
+            assert len(value) > 0
+
     def test_qiskit_addon_modules_not_empty(self):
         """Test that AVAILABLE_ADDONS is not empty."""
         assert len(AVAILABLE_ADDONS) > 0
+
+    def test_qiskit_addons_are_dict_with_descriptions(self):
+        """Test that AVAILABLE_ADDONS values are description strings."""
+        assert isinstance(AVAILABLE_ADDONS, dict)
+        for key, value in AVAILABLE_ADDONS.items():
+            assert isinstance(key, str)
+            assert isinstance(value, str)
+            assert len(value) > 0
+
+    def test_qiskit_guides_not_empty(self):
+        """Test that AVAILABLE_GUIDES is not empty."""
+        assert len(AVAILABLE_GUIDES) > 0
+
+    def test_qiskit_guides_are_dict_with_descriptions(self):
+        """Test that AVAILABLE_GUIDES values are description strings."""
+        assert isinstance(AVAILABLE_GUIDES, dict)
+        for key, value in AVAILABLE_GUIDES.items():
+            assert isinstance(key, str)
+            assert isinstance(value, str)
+            assert len(value) > 0
 
 
 class TestEnvironmentConfiguration:

--- a/qiskit-docs-mcp-server/tests/test_data_fetcher.py
+++ b/qiskit-docs-mcp-server/tests/test_data_fetcher.py
@@ -301,6 +301,20 @@ class TestTruncateContent:
         assert result["content"].endswith("\n")
         assert result["has_more"] is True
 
+    def test_offset_beyond_content_returns_empty(self):
+        """Test that offset beyond content length is clamped and returns empty."""
+        result = _truncate_content("hello", max_length=100, offset=9999)
+        assert result["content"] == ""
+        assert result["has_more"] is False
+        assert result["offset"] == 5  # Clamped to total_length
+        assert result["total_length"] == 5
+
+    def test_offset_at_exact_length_returns_empty(self):
+        """Test that offset exactly at content length returns empty."""
+        result = _truncate_content("hello", max_length=100, offset=5)
+        assert result["content"] == ""
+        assert result["has_more"] is False
+
 
 class TestStripHtmlTags:
     """Test HTML tag stripping."""
@@ -399,6 +413,20 @@ class TestSearchQiskitDocs:
         result = await search_qiskit_docs("circuit")
         assert result["status"] == "success"
         assert len(result["results"]) == 1
+
+    async def test_search_invalid_scope_returns_error(self):
+        """Test that an invalid scope returns an error without calling the API."""
+        result = await search_qiskit_docs("test", scope="invalid")
+        assert result["status"] == "error"
+        assert "Invalid scope" in result["message"]
+        assert "invalid" in result["message"]
+
+    async def test_search_all_valid_scopes_accepted(self):
+        """Test that all documented scopes are accepted."""
+        from qiskit_docs_mcp_server.data_fetcher import _VALID_SCOPES
+
+        for scope in ["all", "documentation", "api", "learning", "tutorials"]:
+            assert scope in _VALID_SCOPES
 
 
 class TestLookupErrorCode:

--- a/qiskit-docs-mcp-server/tests/test_data_fetcher.py
+++ b/qiskit-docs-mcp-server/tests/test_data_fetcher.py
@@ -22,17 +22,16 @@ from qiskit_docs_mcp_server.constants import (
     _get_env_float,
 )
 from qiskit_docs_mcp_server.data_fetcher import (
-    _find_similar,
+    _resolve_url,
+    _strip_html_tags,
     convert_html_to_markdown,
     fetch_text,
     fetch_text_json,
-    get_addon_docs,
-    get_component_docs,
-    get_guide_docs,
     get_list_of_addons,
     get_list_of_error_code_categories,
     get_list_of_guides,
     get_list_of_modules,
+    get_page_docs,
     lookup_error_code,
     search_qiskit_docs,
 )
@@ -132,186 +131,173 @@ class TestFetchTextJson:
         assert isinstance(result, list)
 
 
-class TestGetComponentDocs:
-    """Test get_component_docs function."""
+class TestResolveUrl:
+    """Test URL resolution and validation."""
+
+    def test_resolve_relative_path(self):
+        """Test resolving a relative path."""
+        url = _resolve_url("guides/transpile")
+        assert url == "https://quantum.cloud.ibm.com/docs/guides/transpile"
+
+    def test_resolve_relative_path_with_leading_slash(self):
+        """Test resolving a relative path with leading slash."""
+        url = _resolve_url("/guides/transpile")
+        assert url == "https://quantum.cloud.ibm.com/docs/guides/transpile"
+
+    def test_resolve_api_path(self):
+        """Test resolving an API path."""
+        url = _resolve_url("api/qiskit/circuit")
+        assert url == "https://quantum.cloud.ibm.com/docs/api/qiskit/circuit"
+
+    def test_resolve_class_path(self):
+        """Test resolving a class-level API path."""
+        url = _resolve_url("api/qiskit/qiskit.circuit.QuantumCircuit")
+        assert "qiskit.circuit.QuantumCircuit" in url
+
+    def test_full_url_allowed_domain(self):
+        """Test that full URLs with allowed domain pass through."""
+        url = _resolve_url("https://quantum.cloud.ibm.com/docs/guides/transpile")
+        assert url == "https://quantum.cloud.ibm.com/docs/guides/transpile"
+
+    def test_full_url_disallowed_domain(self):
+        """Test that URLs with disallowed domains raise ValueError."""
+        import pytest
+
+        with pytest.raises(ValueError, match="not allowed"):
+            _resolve_url("https://evil.com/malicious")
+
+    def test_resolve_addon_path(self):
+        """Test resolving an addon path."""
+        url = _resolve_url("api/qiskit-addon-sqd")
+        assert url == "https://quantum.cloud.ibm.com/docs/api/qiskit-addon-sqd"
+
+
+class TestGetPageDocs:
+    """Test get_page_docs function."""
 
     @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_component_docs_valid_module(self, mock_fetch):
-        """Test getting docs for a valid module."""
-        mock_fetch.return_value = "Circuit documentation"
-        result = await get_component_docs("circuit")
-
+    async def test_get_page_relative_path(self, mock_fetch):
+        """Test fetching a page by relative path."""
+        mock_fetch.return_value = "<h1>Circuit</h1><p>Documentation</p>"
+        result = await get_page_docs("api/qiskit/circuit")
         assert result["status"] == "success"
-        assert result["module"] == "circuit"
+        assert "documentation" in result
         assert "metadata" in result
-        mock_fetch.assert_called_once()
+        assert "Circuit" in result["documentation"]
 
     @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_component_docs_invalid_module(self, mock_fetch):
-        """Test getting docs for an invalid module."""
-        result = await get_component_docs("invalid_module")
-        assert result["status"] == "error"
-        assert "not found" in result["message"]
-        assert "available_modules" in result
-        mock_fetch.assert_not_called()
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_component_docs_invalid_with_suggestions(self, mock_fetch):
-        """Test getting docs with similar module suggestions."""
-        result = await get_component_docs("circuitt")  # Typo of 'circuit'
-        assert result["status"] == "error"
-        assert "available_modules" in result
-        # May or may not have suggestions depending on similarity cutoff
-        if "suggestions" in result:
-            assert "circuit" in result["suggestions"]
-        mock_fetch.assert_not_called()
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_component_docs_all_valid_modules(self, mock_fetch):
-        """Test getting docs for all valid modules."""
-        mock_fetch.return_value = "Documentation"
-
-        for module in AVAILABLE_MODULES:
-            result = await get_component_docs(module)
-            assert result["status"] == "success"
-            assert result["module"] == module
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_component_docs_fetch_fails(self, mock_fetch):
-        """Test get_component_docs when fetch fails."""
-        mock_fetch.return_value = None
-        result = await get_component_docs("circuit")
-        assert result["status"] == "error"
-
-
-class TestGetGuideDocs:
-    """Test get_guide_docs function."""
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_guide_docs_valid_guide(self, mock_fetch):
-        """Test getting docs for a valid guide."""
-        mock_fetch.return_value = "Quick start guide"
-        result = await get_guide_docs("quick-start")
-
+    async def test_get_page_full_url(self, mock_fetch):
+        """Test fetching a page by full URL."""
+        mock_fetch.return_value = "<h1>Guide</h1>"
+        result = await get_page_docs("https://quantum.cloud.ibm.com/docs/guides/transpile")
         assert result["status"] == "success"
-        assert result["guide"] == "quick-start"
+
+    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
+    async def test_get_page_fetch_fails(self, mock_fetch):
+        """Test get_page when fetch fails."""
+        mock_fetch.return_value = None
+        result = await get_page_docs("api/qiskit/nonexistent")
+        assert result["status"] == "error"
+        assert "search_docs_tool" in result["message"]
+
+    async def test_get_page_disallowed_domain(self):
+        """Test get_page rejects disallowed domains."""
+        result = await get_page_docs("https://evil.com/page")
+        assert result["status"] == "error"
+        assert "not allowed" in result["message"]
+
+    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
+    async def test_get_page_has_metadata(self, mock_fetch):
+        """Test that get_page response includes metadata."""
+        mock_fetch.return_value = "<p>Content</p>"
+        result = await get_page_docs("guides/quick-start")
         assert "metadata" in result
-        mock_fetch.assert_called_once()
+        assert "url" in result["metadata"]
+        assert "timestamp" in result["metadata"]
 
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_guide_docs_invalid_guide(self, mock_fetch):
-        """Test getting docs for an invalid guide."""
-        result = await get_guide_docs("nonexistent-guide")
-        assert result["status"] == "error"
-        assert "not found" in result["message"]
-        assert "available_guides" in result
-        mock_fetch.assert_not_called()
 
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_guide_docs_invalid_with_suggestions(self, mock_fetch):
-        """Test getting docs with similar guide suggestions."""
-        result = await get_guide_docs(
-            "transpile-with-pass-manager"
-        )  # Similar to 'transpile-with-pass-managers'
-        assert result["status"] == "error"
-        assert "available_guides" in result
-        # May or may not have suggestions depending on similarity cutoff
-        if "suggestions" in result:
-            assert "transpile-with-pass-managers" in result["suggestions"]
-        mock_fetch.assert_not_called()
+class TestStripHtmlTags:
+    """Test HTML tag stripping."""
 
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_guide_docs_all_valid_guides(self, mock_fetch):
-        """Test getting docs for all valid guides."""
-        mock_fetch.return_value = "Guide documentation"
-        valid_guides = [
-            "quick-start",
-            "construct-circuits",
-            "transpile",
-            "dynamic-circuits",
-            "primitives",
-            "configure-error-mitigation",
-        ]
+    def test_strip_em_tags(self):
+        """Test stripping em tags."""
+        assert _strip_html_tags("<em>Transpiler</em> stages") == "Transpiler stages"
 
-        for guide in valid_guides:
-            result = await get_guide_docs(guide)
-            assert result["status"] == "success"
-            assert result["guide"] == guide
+    def test_strip_multiple_tags(self):
+        """Test stripping multiple tags."""
+        assert _strip_html_tags("<em>error</em> <strong>mitigation</strong>") == "error mitigation"
 
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_guide_docs_fetch_fails(self, mock_fetch):
-        """Test get_guide_docs when fetch fails."""
-        mock_fetch.return_value = None
-        result = await get_guide_docs("quick-start")
-        assert result["status"] == "error"
+    def test_no_tags(self):
+        """Test string without tags."""
+        assert _strip_html_tags("plain text") == "plain text"
 
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_guide_docs_error_mitigation(self, mock_fetch):
-        """Test getting error-mitigation guide."""
-        mock_fetch.return_value = "Error mitigation techniques"
-        result = await get_guide_docs("configure-error-mitigation")
-        assert result["status"] == "success"
-        assert result["guide"] == "configure-error-mitigation"
+    def test_empty_string(self):
+        """Test empty string."""
+        assert _strip_html_tags("") == ""
 
 
 class TestSearchQiskitDocs:
     """Test search_qiskit_docs function."""
 
     @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text_json")
-    async def test_search_qiskit_docs_with_results(self, mock_fetch):
+    async def test_search_with_results(self, mock_fetch):
         """Test search with results."""
         mock_fetch.return_value = [
-            {"name": "circuit", "type": "module"},
-            {"name": "optimization", "type": "guide"},
+            {"title": "Circuit", "url": "/docs/api/qiskit/circuit"},
         ]
         result = await search_qiskit_docs("circuit")
-
         assert result["status"] == "success"
         assert result["query"] == "circuit"
-        assert len(result["results"]) == 2
-        assert result["total_results"] == 2
-        assert "metadata" in result
-        mock_fetch.assert_called_once()
+        assert len(result["results"]) == 1
+        assert result["total_results"] == 1
 
     @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text_json")
-    async def test_search_qiskit_docs_no_results(self, mock_fetch):
+    async def test_search_no_results(self, mock_fetch):
         """Test search with no results."""
         mock_fetch.return_value = []
         result = await search_qiskit_docs("nonexistent")
-
         assert result["status"] == "success"
-        assert result["query"] == "nonexistent"
         assert result["results"] == []
         assert result["total_results"] == 0
 
     @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text_json")
-    async def test_search_qiskit_docs_returns_dict(self, mock_fetch):
-        """Test that search returns a dict with proper structure."""
-        mock_fetch.return_value = [{"result": "test"}]
-        result = await search_qiskit_docs("test")
-        assert isinstance(result, dict)
-        assert "status" in result
-        assert "results" in result
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text_json")
-    async def test_search_qiskit_docs_fetch_fails(self, mock_fetch):
-        """Test search when fetch fails returns error status."""
+    async def test_search_fetch_fails(self, mock_fetch):
+        """Test search when fetch fails."""
         mock_fetch.return_value = None
         result = await search_qiskit_docs("circuit")
         assert result["status"] == "error"
-        assert "Failed to search" in result["message"]
 
     @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text_json")
-    async def test_search_qiskit_docs_empty_results(self, mock_fetch):
-        """Test search with empty results list."""
+    async def test_search_strips_html_tags(self, mock_fetch):
+        """Test that HTML tags are stripped from search results."""
+        mock_fetch.return_value = [
+            {
+                "title": "<em>Transpiler</em> options",
+                "text": "<em>Transpiler</em> passes",
+            },
+        ]
+        result = await search_qiskit_docs("transpiler")
+        assert result["results"][0]["title"] == "Transpiler options"
+        assert result["results"][0]["text"] == "Transpiler passes"
+
+    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text_json")
+    async def test_search_uses_scope_param(self, mock_fetch):
+        """Test that scope parameter is passed to API."""
         mock_fetch.return_value = []
-        result = await search_qiskit_docs("nonexistent")
-        assert result["status"] == "success"
-        assert result["results"] == []
-        assert result["total_results"] == 0
+        await search_qiskit_docs("test", scope="api")
+        call_url = mock_fetch.call_args[0][0]
+        assert "module=api" in call_url
 
     @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text_json")
-    async def test_search_qiskit_docs_url_encodes_query(self, mock_fetch):
+    async def test_search_default_scope_is_all(self, mock_fetch):
+        """Test that default scope is 'all'."""
+        mock_fetch.return_value = []
+        await search_qiskit_docs("test")
+        call_url = mock_fetch.call_args[0][0]
+        assert "module=all" in call_url
+
+    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text_json")
+    async def test_search_url_encodes_query(self, mock_fetch):
         """Test that search query is URL-encoded."""
         mock_fetch.return_value = []
         await search_qiskit_docs("error mitigation")
@@ -319,94 +305,137 @@ class TestSearchQiskitDocs:
         assert "error%20mitigation" in call_url
 
 
-class TestFuzzyMatching:
-    """Test fuzzy matching functionality."""
+class TestLookupErrorCode:
+    """Test lookup_error_code function."""
 
-    def test_find_similar_exact_match(self):
-        """Test finding exact match."""
-        available = ["circuit", "primitives", "transpiler"]
-        result = _find_similar("circuit", available)
-        assert "circuit" in result
+    async def test_invalid_code_format_letters(self):
+        """Test that non-numeric codes return an error."""
+        result = await lookup_error_code("abcd")
+        assert result["status"] == "error"
+        assert "Invalid error code format" in result["message"]
 
-    def test_find_similar_typo_match(self):
-        """Test finding close match with typo."""
-        available = ["circuit", "primitives", "transpiler"]
-        result = _find_similar("circuitt", available)
-        assert "circuit" in result
+    async def test_invalid_code_format_short(self):
+        """Test that codes with wrong length return an error."""
+        result = await lookup_error_code("12")
+        assert result["status"] == "error"
 
-    def test_find_similar_no_match(self):
-        """Test no match returns empty list."""
-        available = ["circuit", "primitives", "transpiler"]
-        result = _find_similar("xyz123", available)
-        assert len(result) == 0
-
-    def test_find_similar_empty_available(self):
-        """Test with empty available list."""
-        result = _find_similar("circuit", [])
-        assert result == []
-
-    def test_find_similar_empty_query(self):
-        """Test with empty query."""
-        available = ["circuit", "primitives", "transpiler"]
-        result = _find_similar("", available)
-        assert result == []
-
-    def test_find_similar_partial_match(self):
-        """Test finding partial matches."""
-        available = ["optimization", "quantum-circuits", "error-mitigation"]
-        # Test with a query that should match "error-mitigation"
-        result = _find_similar("error", available, cutoff=0.5)
-        assert isinstance(result, list)
-        # May or may not have matches depending on similarity
-
-    def test_find_similar_limit_results(self):
-        """Test that results are limited to 3."""
-        available = ["circuit", "circuits", "circuitry", "circular", "circulate"]
-        result = _find_similar("circuit", available)
-        # difflib.get_close_matches returns at most n=3 by default
-        assert len(result) <= 3
-
-
-class TestMetadataHandling:
-    """Test metadata functionality."""
+    async def test_invalid_code_format_long(self):
+        """Test that 5-digit codes return an error."""
+        result = await lookup_error_code("12345")
+        assert result["status"] == "error"
 
     @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_component_docs_has_metadata(self, mock_fetch):
-        """Test that component docs response includes metadata."""
-        mock_fetch.return_value = "Documentation"
-        result = await get_component_docs("circuit")
-
-        assert "metadata" in result
-        metadata = result["metadata"]
-        assert "url" in metadata
-        assert "timestamp" in metadata
-        assert "content_type" in metadata
-        assert "content_length" in metadata
-        assert metadata["content_type"] == "markdown"
+    async def test_fetch_failure(self, mock_fetch):
+        """Test lookup when fetch fails."""
+        mock_fetch.return_value = None
+        result = await lookup_error_code("1002")
+        assert result["status"] == "error"
 
     @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_guide_docs_has_metadata(self, mock_fetch):
-        """Test that guide docs response includes metadata."""
-        mock_fetch.return_value = "Guide content"
-        result = await get_guide_docs("quick-start")
+    async def test_code_found(self, mock_fetch):
+        """Test successful error code lookup."""
+        mock_fetch.return_value = (
+            "<table><tr><td>1002</td>"
+            "<td>Error in the validation process.</td>"
+            "<td>Check the job.</td></tr></table>"
+        )
+        result = await lookup_error_code("1002")
+        assert result["status"] == "success"
+        assert result["code"] == "1002"
+        assert "1002" in result["details"]
 
-        assert "metadata" in result
-        metadata = result["metadata"]
-        assert "url" in metadata
-        assert "timestamp" in metadata
-        assert metadata["content_type"] == "markdown"
+    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
+    async def test_code_not_found(self, mock_fetch):
+        """Test lookup for a code that does not exist."""
+        mock_fetch.return_value = "<table><tr><td>1002</td><td>Some error</td></tr></table>"
+        result = await lookup_error_code("9999")
+        assert result["status"] == "error"
+        assert "not found" in result["message"]
 
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text_json")
-    async def test_search_docs_has_metadata(self, mock_fetch):
-        """Test that search docs response includes metadata."""
-        mock_fetch.return_value = [{"name": "circuit"}]
-        result = await search_qiskit_docs("circuit")
 
-        assert "metadata" in result
-        metadata = result["metadata"]
-        assert "url" in metadata
-        assert "timestamp" in metadata
-        assert metadata["content_type"] == "json"
+class TestConvertHtmlToMarkdown:
+    """Test convert_html_to_markdown function."""
+
+    def test_basic_html(self):
+        """Test conversion of basic HTML."""
+        html = "<h1>Title</h1><p>Paragraph text.</p>"
+        result = convert_html_to_markdown(html)
+        assert "Title" in result
+        assert "Paragraph text." in result
+
+    def test_links_preserved(self):
+        """Test that links are preserved."""
+        html = '<a href="https://example.com">Click here</a>'
+        result = convert_html_to_markdown(html)
+        assert "https://example.com" in result
+
+    def test_empty_html(self):
+        """Test conversion of empty HTML."""
+        result = convert_html_to_markdown("")
+        assert result.strip() == ""
+
+
+class TestListHelpers:
+    """Test list helper functions."""
+
+    def test_get_list_of_modules(self):
+        """Test get_list_of_modules returns correct structure with url_path."""
+        result = get_list_of_modules()
+        assert result["status"] == "success"
+        assert "modules" in result
+        assert isinstance(result["modules"], list)
+        assert len(result["modules"]) > 0
+        # Check structure includes url_path
+        first = result["modules"][0]
+        assert "name" in first
+        assert "url_path" in first
+        assert first["url_path"].startswith("api/qiskit/")
+
+    def test_get_list_of_addons(self):
+        """Test get_list_of_addons returns correct structure with url_path."""
+        result = get_list_of_addons()
+        assert result["status"] == "success"
+        assert "addons" in result
+        assert len(result["addons"]) > 0
+        first = result["addons"][0]
+        assert "name" in first
+        assert "url_path" in first
+        assert "qiskit-addon-" in first["url_path"]
+
+    def test_get_list_of_guides(self):
+        """Test get_list_of_guides returns correct structure with url_path."""
+        result = get_list_of_guides()
+        assert result["status"] == "success"
+        assert "guides" in result
+        assert len(result["guides"]) > 0
+        first = result["guides"][0]
+        assert "name" in first
+        assert "url_path" in first
+        assert first["url_path"].startswith("guides/")
+
+    def test_get_list_of_error_code_categories(self):
+        """Test get_list_of_error_code_categories returns correct structure."""
+        result = get_list_of_error_code_categories()
+        assert result["status"] == "success"
+        assert "categories" in result
+        assert isinstance(result["categories"], dict)
+        assert "registry_url" in result
+
+
+class TestDocFetcherConstants:
+    """Test data_fetcher constants."""
+
+    def test_qiskit_modules_not_empty(self):
+        """Test that AVAILABLE_MODULES is not empty."""
+        assert len(AVAILABLE_MODULES) > 0
+
+    def test_qiskit_modules_has_circuit(self):
+        """Test that AVAILABLE_MODULES contains circuit."""
+        assert "circuit" in AVAILABLE_MODULES
+
+    def test_qiskit_addon_modules_not_empty(self):
+        """Test that AVAILABLE_ADDONS is not empty."""
+        assert len(AVAILABLE_ADDONS) > 0
 
 
 class TestEnvironmentConfiguration:
@@ -450,272 +479,4 @@ class TestEnvironmentConfiguration:
     def test_http_timeout_default(self):
         """Test that HTTP_TIMEOUT has a reasonable default."""
         assert HTTP_TIMEOUT > 0
-        assert HTTP_TIMEOUT <= 30.0  # Reasonable timeout range
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.httpx.AsyncClient")
-    async def test_fetch_text_uses_http_timeout(self, mock_client_class):
-        """Test that fetch_text uses HTTP_TIMEOUT."""
-        mock_response = MagicMock()
-        mock_response.text = "Content"
-        mock_client = AsyncMock()
-        mock_client.get.return_value = mock_response
-        mock_client_class.return_value.__aenter__.return_value = mock_client
-
-        await fetch_text("https://example.com")
-
-        # Verify httpx.AsyncClient was called with timeout parameter
-        mock_client_class.assert_called_once()
-        call_kwargs = mock_client_class.call_args[1]
-        assert "timeout" in call_kwargs
-        assert call_kwargs["timeout"] == HTTP_TIMEOUT
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.httpx.AsyncClient")
-    async def test_fetch_text_json_uses_http_timeout(self, mock_client_class):
-        """Test that fetch_text_json uses HTTP_TIMEOUT."""
-        mock_response = MagicMock()
-        mock_response.json.return_value = []
-        mock_client = AsyncMock()
-        mock_client.get.return_value = mock_response
-        mock_client_class.return_value.__aenter__.return_value = mock_client
-
-        await fetch_text_json("https://example.com/api")
-
-        # Verify httpx.AsyncClient was called with timeout parameter
-        mock_client_class.assert_called_once()
-        call_kwargs = mock_client_class.call_args[1]
-        assert "timeout" in call_kwargs
-        assert call_kwargs["timeout"] == HTTP_TIMEOUT
-
-
-class TestDocFetcherConstants:
-    """Test data_fetcher constants."""
-
-    def test_qiskit_modules_not_empty(self):
-        """Test that AVAILABLE_MODULES is not empty."""
-        assert len(AVAILABLE_MODULES) > 0
-
-    def test_qiskit_modules_has_circuit(self):
-        """Test that AVAILABLE_MODULES contains circuit."""
-        assert "circuit" in AVAILABLE_MODULES
-
-    def test_qiskit_modules_has_primitives(self):
-        """Test that AVAILABLE_MODULES contains primitives."""
-        assert "primitives" in AVAILABLE_MODULES
-
-    def test_qiskit_modules_has_transpiler(self):
-        """Test that AVAILABLE_MODULES contains transpiler."""
-        assert "transpiler" in AVAILABLE_MODULES
-
-    def test_qiskit_addon_modules_not_empty(self):
-        """Test that AVAILABLE_ADDONS is not empty."""
-        assert len(AVAILABLE_ADDONS) > 0
-
-    def test_qiskit_addon_modules_has_sqd(self):
-        """Test that AVAILABLE_ADDONS contains SQD."""
-        assert "sqd" in AVAILABLE_ADDONS
-
-    def test_qiskit_addon_modules_has_cutting(self):
-        """Test that AVAILABLE_ADDONS contains cutting."""
-        assert "cutting" in AVAILABLE_ADDONS
-
-    def test_qiskit_modules_entries_are_strings(self):
-        """Test that AVAILABLE_MODULES entries are strings."""
-        for value in AVAILABLE_MODULES:
-            assert isinstance(value, str)
-
-    def test_qiskit_addon_modules_entries_are_strings(self):
-        """Test that AVAILABLE_ADDONS entries are strings."""
-        for value in AVAILABLE_ADDONS:
-            assert isinstance(value, str)
-
-
-class TestLookupErrorCode:
-    """Test lookup_error_code function."""
-
-    async def test_invalid_code_format_letters(self):
-        """Test that non-numeric codes return an error."""
-        result = await lookup_error_code("abcd")
-        assert result["status"] == "error"
-        assert "Invalid error code format" in result["message"]
-
-    async def test_invalid_code_format_short(self):
-        """Test that codes with wrong length return an error."""
-        result = await lookup_error_code("12")
-        assert result["status"] == "error"
-        assert "Invalid error code format" in result["message"]
-
-    async def test_invalid_code_format_long(self):
-        """Test that 5-digit codes return an error."""
-        result = await lookup_error_code("12345")
-        assert result["status"] == "error"
-        assert "Invalid error code format" in result["message"]
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_fetch_failure(self, mock_fetch):
-        """Test lookup when fetch fails."""
-        mock_fetch.return_value = None
-        result = await lookup_error_code("1002")
-        assert result["status"] == "error"
-        assert "Failed to fetch" in result["message"]
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_code_found(self, mock_fetch):
-        """Test successful error code lookup."""
-        mock_fetch.return_value = (
-            "<table><tr><td>1002</td>"
-            "<td>Error in the validation process.</td>"
-            "<td>Check the job.</td></tr></table>"
-        )
-        result = await lookup_error_code("1002")
-        assert result["status"] == "success"
-        assert result["code"] == "1002"
-        assert "details" in result
-        assert "1002" in result["details"]
-        assert "metadata" in result
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_code_not_found(self, mock_fetch):
-        """Test lookup for a code that does not exist in the page."""
-        mock_fetch.return_value = "<table><tr><td>1002</td><td>Some error</td></tr></table>"
-        result = await lookup_error_code("9999")
-        assert result["status"] == "error"
-        assert "not found" in result["message"]
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_metadata_url_includes_range(self, mock_fetch):
-        """Test that metadata URL points to the correct error range anchor."""
-        mock_fetch.return_value = "<table><tr><td>7001</td><td>Error</td><td>Fix</td></tr></table>"
-        result = await lookup_error_code("7001")
-        assert result["status"] == "success"
-        assert "7xxx" in result["metadata"]["url"]
-
-
-class TestGetAddonDocs:
-    """Test get_addon_docs function."""
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_addon_docs_valid(self, mock_fetch):
-        """Test getting docs for a valid addon."""
-        mock_fetch.return_value = "SQD documentation"
-        result = await get_addon_docs("sqd")
-        assert result["status"] == "success"
-        assert result["addon"] == "sqd"
-        assert "metadata" in result
-        assert "qiskit-addon-sqd" in result["metadata"]["url"]
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_addon_docs_invalid(self, mock_fetch):
-        """Test getting docs for an invalid addon."""
-        result = await get_addon_docs("nonexistent")
-        assert result["status"] == "error"
-        assert "not found" in result["message"]
-        assert "available_addons" in result
-        mock_fetch.assert_not_called()
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_addon_docs_with_suggestions(self, mock_fetch):
-        """Test getting docs with fuzzy match suggestions."""
-        result = await get_addon_docs("cut")
-        assert result["status"] == "error"
-        if "suggestions" in result:
-            assert "cutting" in result["suggestions"]
-        mock_fetch.assert_not_called()
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_addon_docs_fetch_fails(self, mock_fetch):
-        """Test get_addon_docs when fetch fails."""
-        mock_fetch.return_value = None
-        result = await get_addon_docs("cutting")
-        assert result["status"] == "error"
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_addon_docs_all_valid(self, mock_fetch):
-        """Test getting docs for all valid addons."""
-        mock_fetch.return_value = "Addon docs"
-        for addon in AVAILABLE_ADDONS:
-            result = await get_addon_docs(addon)
-            assert result["status"] == "success"
-            assert result["addon"] == addon
-
-
-class TestConvertHtmlToMarkdown:
-    """Test convert_html_to_markdown function."""
-
-    def test_basic_html(self):
-        """Test conversion of basic HTML tags."""
-        html = "<h1>Title</h1><p>Paragraph text.</p>"
-        result = convert_html_to_markdown(html)
-        assert "Title" in result
-        assert "Paragraph text." in result
-
-    def test_links_preserved(self):
-        """Test that links are preserved in markdown output."""
-        html = '<a href="https://example.com">Click here</a>'
-        result = convert_html_to_markdown(html)
-        assert "https://example.com" in result
-        assert "Click here" in result
-
-    def test_empty_html(self):
-        """Test conversion of empty HTML."""
-        result = convert_html_to_markdown("")
-        assert result.strip() == ""
-
-    def test_nested_html(self):
-        """Test conversion of nested HTML structures."""
-        html = "<div><ul><li>Item 1</li><li>Item 2</li></ul></div>"
-        result = convert_html_to_markdown(html)
-        assert "Item 1" in result
-        assert "Item 2" in result
-
-    def test_code_blocks(self):
-        """Test conversion of code blocks."""
-        html = "<pre><code>print('hello')</code></pre>"
-        result = convert_html_to_markdown(html)
-        assert "print('hello')" in result
-
-    def test_table_html(self):
-        """Test conversion of HTML tables."""
-        html = "<table><tr><td>1002</td><td>Error message</td></tr></table>"
-        result = convert_html_to_markdown(html)
-        assert "1002" in result
-        assert "Error message" in result
-
-
-class TestListHelpers:
-    """Test list helper functions."""
-
-    def test_get_list_of_modules(self):
-        """Test get_list_of_modules returns correct structure."""
-        result = get_list_of_modules()
-        assert result["status"] == "success"
-        assert "modules" in result
-        assert isinstance(result["modules"], list)
-        assert len(result["modules"]) > 0
-        assert "circuit" in result["modules"]
-
-    def test_get_list_of_addons(self):
-        """Test get_list_of_addons returns correct structure."""
-        result = get_list_of_addons()
-        assert result["status"] == "success"
-        assert "addons" in result
-        assert isinstance(result["addons"], list)
-        assert len(result["addons"]) > 0
-        assert "sqd" in result["addons"]
-
-    def test_get_list_of_guides(self):
-        """Test get_list_of_guides returns correct structure."""
-        result = get_list_of_guides()
-        assert result["status"] == "success"
-        assert "guides" in result
-        assert isinstance(result["guides"], list)
-        assert len(result["guides"]) > 0
-        assert "quick-start" in result["guides"]
-
-    def test_get_list_of_error_code_categories(self):
-        """Test get_list_of_error_code_categories returns correct structure."""
-        result = get_list_of_error_code_categories()
-        assert result["status"] == "success"
-        assert "categories" in result
-        assert isinstance(result["categories"], dict)
-        assert "registry_url" in result
-        assert "errors" in result["registry_url"]
+        assert HTTP_TIMEOUT <= 30.0

--- a/qiskit-docs-mcp-server/tests/test_data_fetcher.py
+++ b/qiskit-docs-mcp-server/tests/test_data_fetcher.py
@@ -28,6 +28,7 @@ from qiskit_docs_mcp_server.data_fetcher import (
     _strip_html_tags,
     _truncate_content,
     convert_html_to_markdown,
+    extract_main_content,
     fetch_text,
     fetch_text_json,
     get_list_of_addons,
@@ -475,6 +476,114 @@ class TestLookupErrorCode:
         result = await lookup_error_code("9999")
         assert result["status"] == "error"
         assert "not found" in result["message"]
+
+
+class TestExtractMainContent:
+    """Test main content extraction from HTML."""
+
+    def test_extracts_main_tag(self):
+        """Test extraction of main tag content."""
+        html = "<html><body><nav>Nav</nav><main><h1>Title</h1><p>Content</p></main><footer>Footer</footer></body></html>"
+        result = extract_main_content(html)
+        assert "Title" in result
+        assert "Content" in result
+        assert "Nav" not in result
+        assert "Footer" not in result
+
+    def test_extracts_article_fallback(self):
+        """Test fallback to article tag."""
+        html = "<html><body><nav>Nav</nav><article><h1>Title</h1></article></body></html>"
+        result = extract_main_content(html)
+        assert "Title" in result
+        assert "Nav" not in result
+
+    def test_extracts_role_main_fallback(self):
+        """Test fallback to role=main."""
+        html = '<html><body><nav>Nav</nav><div role="main"><p>Content</p></div></body></html>'
+        result = extract_main_content(html)
+        assert "Content" in result
+        assert "Nav" not in result
+
+    def test_removes_nav_elements(self):
+        """Test that nav elements are removed."""
+        html = "<html><body><nav>Navigation</nav><main><p>Content</p></main></body></html>"
+        result = extract_main_content(html)
+        assert "Navigation" not in result
+
+    def test_removes_header_elements(self):
+        """Test that header elements are removed."""
+        html = "<html><body><header>Header</header><main><p>Content</p></main></body></html>"
+        result = extract_main_content(html)
+        assert "Header" not in result
+
+    def test_removes_footer_elements(self):
+        """Test that footer elements are removed."""
+        html = "<html><body><main><p>Content</p></main><footer>Footer</footer></body></html>"
+        result = extract_main_content(html)
+        assert "Footer" not in result
+
+    def test_removes_aside_elements(self):
+        """Test that aside elements are removed."""
+        html = "<html><body><aside>Sidebar</aside><main><p>Content</p></main></body></html>"
+        result = extract_main_content(html)
+        assert "Sidebar" not in result
+
+    def test_removes_navigation_role(self):
+        """Test that elements with role=navigation are removed."""
+        html = (
+            '<html><body><div role="navigation">Nav</div><main><p>Content</p></main></body></html>'
+        )
+        result = extract_main_content(html)
+        assert "Nav" not in result
+
+    def test_removes_skip_links(self):
+        """Test that skip-to-content links are removed."""
+        html = '<html><body><a class="skip-link">Skip to main content</a><main><p>Content</p></main></body></html>'
+        result = extract_main_content(html)
+        assert "Skip to main content" not in result
+
+    def test_body_fallback(self):
+        """Test fallback to body when no main/article found."""
+        html = "<html><body><nav>Nav</nav><div><p>Content</p></div></body></html>"
+        result = extract_main_content(html)
+        assert "Content" in result
+        assert "Nav" not in result
+
+    def test_empty_html(self):
+        """Test with empty HTML."""
+        result = extract_main_content("")
+        assert result is not None
+
+    def test_plain_content(self):
+        """Test with simple content without structure."""
+        html = "<p>Just a paragraph</p>"
+        result = extract_main_content(html)
+        assert "Just a paragraph" in result
+
+
+class TestConvertHtmlToMarkdownWithExtraction:
+    """Test that convert_html_to_markdown strips chrome before converting."""
+
+    def test_chrome_not_in_markdown(self):
+        """Test that navigation chrome is not in final markdown output."""
+        html = """
+        <html>
+        <body>
+            <nav><ul><li><a href="/">Home</a></li><li><a href="/docs">Docs</a></li></ul></nav>
+            <header><h1>IBM Quantum Platform</h1></header>
+            <main>
+                <h1>Circuit Module</h1>
+                <p>The circuit module provides QuantumCircuit class.</p>
+            </main>
+            <footer><p>Copyright IBM 2026</p></footer>
+        </body>
+        </html>
+        """
+        result = convert_html_to_markdown(html)
+        assert "Circuit Module" in result
+        assert "QuantumCircuit" in result
+        assert "IBM Quantum Platform" not in result
+        assert "Copyright IBM" not in result
 
 
 class TestConvertHtmlToMarkdown:

--- a/qiskit-docs-mcp-server/tests/test_data_fetcher.py
+++ b/qiskit-docs-mcp-server/tests/test_data_fetcher.py
@@ -390,6 +390,16 @@ class TestSearchQiskitDocs:
         call_url = mock_fetch.call_args[0][0]
         assert "error%20mitigation" in call_url
 
+    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text_json")
+    async def test_search_results_missing_title_text_keys(self, mock_fetch):
+        """Test that search results without title/text keys don't error."""
+        mock_fetch.return_value = [
+            {"url": "/docs/api/qiskit/circuit"},
+        ]
+        result = await search_qiskit_docs("circuit")
+        assert result["status"] == "success"
+        assert len(result["results"]) == 1
+
 
 class TestLookupErrorCode:
     """Test lookup_error_code function."""

--- a/qiskit-docs-mcp-server/tests/test_server.py
+++ b/qiskit-docs-mcp-server/tests/test_server.py
@@ -26,10 +26,8 @@ class TestServerRegistration:
         """Test that all expected tools are registered."""
         tool_names = {tool.name for tool in mcp._tool_manager._tools.values()}
         expected_tools = {
-            "get_sdk_module_docs_tool",
-            "get_addon_docs_tool",
-            "get_guide_tool",
             "search_docs_tool",
+            "get_page_tool",
             "lookup_error_code_tool",
         }
         assert expected_tools.issubset(tool_names), f"Missing tools: {expected_tools - tool_names}"
@@ -49,8 +47,20 @@ class TestServerRegistration:
 
     def test_tool_count(self):
         """Test the expected number of tools."""
-        assert len(mcp._tool_manager._tools) == 5
+        assert len(mcp._tool_manager._tools) == 3
 
     def test_resource_count(self):
         """Test the expected number of resources."""
         assert len(mcp._resource_manager._resources) == 4
+
+    def test_old_tools_removed(self):
+        """Test that old category-specific tools are no longer registered."""
+        tool_names = {tool.name for tool in mcp._tool_manager._tools.values()}
+        removed_tools = {
+            "get_sdk_module_docs_tool",
+            "get_addon_docs_tool",
+            "get_guide_tool",
+        }
+        assert removed_tools.isdisjoint(tool_names), (
+            f"Old tools still registered: {removed_tools & tool_names}"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -4644,6 +4644,7 @@ name = "qiskit-docs-mcp-server"
 version = "0.1.1"
 source = { editable = "qiskit-docs-mcp-server" }
 dependencies = [
+    { name = "beautifulsoup4" },
     { name = "fastmcp" },
     { name = "html2text" },
     { name = "httpx" },
@@ -4676,6 +4677,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "fastmcp", specifier = ">=2.8.1,<3" },
     { name = "html2text", specifier = ">=2020.1.16" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
## Summary

Closes #159

Redesigns the qiskit-docs-mcp-server from 5 category-specific tools to 3 general-purpose tools, following a search-first architecture:

- **`search_docs_tool`** — Primary entry point to discover documentation pages. Renamed `module` param to `scope`, default changed from `"documentation"` to `"all"`.
- **`get_page_tool`** — Fetches ANY Qiskit documentation page by URL or relative path (replaces `get_sdk_module_docs_tool`, `get_addon_docs_tool`, `get_guide_tool`). Includes pagination support via `max_length`/`offset` params.
- **`lookup_error_code_tool`** — Unchanged behavior, improved descriptions.

### Additional changes
- **URL validation**: `_resolve_url` validates domains against `_ALLOWED_HOST` derived from configurable `QISKIT_DOCS_BASE` (not hardcoded)
- **Pagination**: `_truncate_content` with line-boundary snapping and input clamping for negative values
- **Dict-based constants**: `AVAILABLE_MODULES`/`ADDONS`/`GUIDES` converted from `list[str]` to `dict[str, str]` with descriptions
- **Resource list helpers**: Now return `{name, description, url_path}` for each entry
- **HTML tag stripping**: Defensive copy pattern in search results to avoid mutating cached data
- **Tests**: 72 tests covering all new functions (URL resolution, pagination, truncation, HTML stripping, dict constants)

### Removed
- `get_sdk_module_docs_tool`, `get_addon_docs_tool`, `get_guide_tool` (replaced by `get_page_tool`)
- `get_component_docs`, `get_addon_docs`, `get_guide_docs` (replaced by `get_page_docs`)
- `_find_similar` fuzzy matching (no longer needed — `get_page_tool` accepts any URL)
- `difflib` import