### PR TITLE
feat(docs-server): improve tool and resource descriptions

### DIFF
--- a/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/constants.py
+++ b/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/constants.py
@@ -59,83 +59,83 @@ ERROR_CODE_CATEGORIES = {
 HTTP_TIMEOUT = _get_env_float("QISKIT_HTTP_TIMEOUT", 10.0)
 
 # Qiskit modules and their documentation paths
-AVAILABLE_MODULES = [
+AVAILABLE_MODULES = {
     # Circuit construction
-    "circuit",
+    "circuit": "Quantum circuit construction and manipulation (QuantumCircuit, gates, registers)",
     # Quantum information
-    "quantum_info",
+    "quantum_info": "Quantum information utilities (states, operators, channels, measures)",
     # Transpilation
-    "transpiler",
-    "synthesis",
-    "dagcircuit",
-    "passmanager",
-    "converters",
-    "compiler",
+    "transpiler": "Circuit transpilation and optimization for target hardware",
+    "synthesis": "Circuit synthesis algorithms (unitary, Clifford, linear functions)",
+    "dagcircuit": "Directed acyclic graph (DAG) representation of quantum circuits",
+    "passmanager": "Transpiler pass manager framework for custom transpilation pipelines",
+    "converters": "Circuit format converters and interoperability utilities",
+    "compiler": "High-level compilation routines (transpile shortcut)",
     # Primitives and providers
-    "primitives",
-    "providers",
+    "primitives": "Sampler and Estimator primitives for quantum execution",
+    "providers": "Backend providers and job management interfaces",
     # Results and visualization
-    "result",
-    "visualization",
+    "result": "Quantum job result handling and analysis",
+    "visualization": "Circuit and result visualization tools",
     # Serialization
-    "qasm2",
-    "qasm3",
-    "qpy",
+    "qasm2": "OpenQASM 2.0 parsing and generation",
+    "qasm3": "OpenQASM 3.0 parsing and generation",
+    "qpy": "Qiskit Python serialization format (QPY) for circuit persistence",
     # Utilities
-    "utils",
-    "exceptions",
-]
+    "utils": "General utility functions and helpers",
+    "exceptions": "Qiskit exception classes and error hierarchy",
+}
 
-AVAILABLE_ADDONS = [
-    "aqc-tensor",
-    "cutting",
-    "mpf",
-    "obp",
-    "sqd",
-    "utils",
-]
+AVAILABLE_ADDONS = {
+    "aqc-tensor": "Approximate Quantum Compiler with tensor network techniques",
+    "cutting": "Circuit cutting to run large circuits on smaller devices",
+    "mpf": "Multi-product formulas for Hamiltonian simulation",
+    "obp": "Operator backpropagation for expectation value estimation",
+    "sqd": "Sample-based Quantum Diagonalization for chemistry and optimization",
+    "utils": "Shared utilities for Qiskit addon packages",
+}
 
-AVAILABLE_GUIDES = [
+AVAILABLE_GUIDES = {
     # Getting started
-    "quick-start",
+    "quick-start": "Get started with Qiskit — create and run your first circuit",
     # Circuit building
-    "construct-circuits",
+    "construct-circuits": "Build and manipulate quantum circuits",
     # Transpilation
-    "transpile",
-    "transpiler-stages",
-    "transpile-with-pass-managers",
-    "defaults-and-configuration-options",
-    "circuit-transpilation-settings",
-    "qiskit-transpiler-service",
+    "transpile": "Transpile circuits for target backends",
+    "transpiler-stages": "Understand the six stages of the transpiler pipeline",
+    "transpile-with-pass-managers": "Use custom pass managers for transpilation",
+    "defaults-and-configuration-options": "Transpiler defaults and configuration options",
+    "circuit-transpilation-settings": "Circuit-level transpilation settings",
+    "qiskit-transpiler-service": "Use the Qiskit Transpiler cloud service",
     # Error mitigation and suppression
-    "error-mitigation-and-suppression-techniques",
-    "configure-error-mitigation",
-    "configure-error-suppression",
+    "error-mitigation-and-suppression-techniques": "Overview of error mitigation and suppression techniques",
+    "configure-error-mitigation": "Configure error mitigation for Qiskit primitives",
+    "configure-error-suppression": "Configure error suppression techniques",
     # Execution
-    "primitives",
-    "execution-modes",
-    "runtime-options-overview",
-    "directed-execution-model",
+    "primitives": "Use Sampler and Estimator primitives for quantum execution",
+    "execution-modes": "Job, session, and batch execution modes",
+    "runtime-options-overview": "Overview of Qiskit Runtime configuration options",
+    "directed-execution-model": "Use the directed execution model",
     # Dynamic circuits
-    "dynamic-circuits",
+    "dynamic-circuits": "Mid-circuit measurements and classical control flow",
     # Post-processing addons
-    "qiskit-addons-sqd",
+    "qiskit-addons-sqd": "Use Sample-based Quantum Diagonalization (SQD)",
     # Qiskit Functions - circuit functions
-    "functions",
-    "ibm-circuit-function",
-    "algorithmiq-tem",
-    "qedma-qesem",
-    "q-ctrl-performance-management",
+    "functions": "Overview of Qiskit Functions",
+    "ibm-circuit-function": "IBM Circuit Function for optimized execution",
+    "algorithmiq-tem": "Algorithmiq Tensor Error Mitigation (TEM)",
+    "qedma-qesem": "Qedma Quantum Error Suppression and Error Mitigation (QESEM)",
+    "q-ctrl-performance-management": "Q-CTRL Performance Management for optimized circuits",
     # Qiskit Functions - application functions
-    "colibritd-pde",
-    "global-data-quantum-optimizer",
-    "qunova-chemistry",
-    "kipu-optimization",
-    "q-ctrl-optimization-solver",
-    "multiverse-computing-singularity",
+    "colibritd-pde": "ColibrITD PDE solver function",
+    "global-data-quantum-optimizer": "Global Data Quantum Optimizer function",
+    "qunova-chemistry": "Qunova Chemistry solver function",
+    "kipu-optimization": "Kipu Optimization solver function",
+    "q-ctrl-optimization-solver": "Q-CTRL Optimization Solver function",
+    "multiverse-computing-singularity": "Multiverse Computing Singularity function",
     # Security and support
-    "secure-data",
-    "support",
-]
+    "secure-data": "Data security and privacy on IBM Quantum",
+    "support": "Getting support and help with Qiskit and IBM Quantum",
+}
 
 SEARCH_PATH = "endpoints-docs-learning/api/search"

--- a/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/data_fetcher.py
+++ b/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/data_fetcher.py
@@ -10,12 +10,11 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-import difflib
 import logging
 import re
 from datetime import datetime, timezone
 from typing import Any
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 import html2text
 import httpx
@@ -34,29 +33,24 @@ from qiskit_docs_mcp_server.constants import (
 
 logger = logging.getLogger(__name__)
 
+# Allowed hostname for URL validation (derived from configurable QISKIT_DOCS_BASE)
+_ALLOWED_HOST = urlparse(QISKIT_DOCS_BASE).netloc
 
-def _find_similar(query: str, available: list[str], cutoff: float = 0.6) -> list[str]:
-    """
-    Find similar strings using difflib.get_close_matches.
+
+def _strip_html_tags(text: str) -> str:
+    """Strip HTML tags from a string.
 
     Args:
-        query: The query string to match
-        available: List of available options to search
-        cutoff: Similarity threshold (0.0-1.0), default 0.6
+        text: String potentially containing HTML tags
 
     Returns:
-        List of similar strings, sorted by similarity (highest first)
+        String with all HTML tags removed
     """
-    if not query or not available:
-        return []
-
-    matches = difflib.get_close_matches(query, available, n=3, cutoff=cutoff)
-    return matches
+    return re.sub(r"<[^>]+>", "", text)
 
 
 def convert_html_to_markdown(html: str) -> str:
-    """
-    Convert HTML content to Markdown format.
+    """Convert HTML content to Markdown format.
 
     Args:
         html: HTML content string
@@ -69,6 +63,92 @@ def convert_html_to_markdown(html: str) -> str:
     h.body_width = 0
     h.ignore_images = False
     return h.handle(html)
+
+
+def _truncate_content(content: str, max_length: int = 20000, offset: int = 0) -> dict[str, Any]:
+    """Truncate content with pagination metadata.
+
+    Args:
+        content: The full content string
+        max_length: Maximum number of characters to return (0 for unlimited)
+        offset: Character offset to start from (negative values clamped to 0)
+
+    Returns:
+        Dict with 'content', 'has_more', 'offset', 'next_offset', 'total_length'
+    """
+    # Clamp invalid inputs
+    offset = max(0, offset)
+    max_length = max(0, max_length)
+
+    total_length = len(content)
+
+    if max_length <= 0:
+        return {
+            "content": content[offset:] if offset > 0 else content,
+            "has_more": False,
+            "offset": offset,
+            "next_offset": None,
+            "total_length": total_length,
+        }
+
+    # Apply offset
+    sliced = content[offset:]
+
+    if len(sliced) <= max_length:
+        return {
+            "content": sliced,
+            "has_more": False,
+            "offset": offset,
+            "next_offset": None,
+            "total_length": total_length,
+        }
+
+    # Truncate at a line boundary if possible
+    truncated = sliced[:max_length]
+    last_newline = truncated.rfind("\n")
+    if last_newline > max_length * 0.8:  # Only snap to newline if reasonably close
+        truncated = truncated[: last_newline + 1]
+
+    next_offset = offset + len(truncated)
+
+    return {
+        "content": truncated,
+        "has_more": True,
+        "offset": offset,
+        "next_offset": next_offset,
+        "total_length": total_length,
+    }
+
+
+def _resolve_url(url: str) -> str:
+    """Resolve a URL or relative path to a full documentation URL.
+
+    Args:
+        url: Full URL or path relative to docs base
+            (e.g., 'guides/transpile' or 'api/qiskit/circuit')
+
+    Returns:
+        Full resolved URL
+
+    Raises:
+        ValueError: If the URL is outside the allowed documentation domain
+    """
+    # If it's already a full URL, validate the domain
+    parsed = urlparse(url)
+    if parsed.scheme and parsed.netloc:
+        if parsed.netloc != _ALLOWED_HOST:
+            msg = (
+                f"URL domain '{parsed.netloc}' is not allowed. "
+                f"Only URLs from '{_ALLOWED_HOST}' are supported."
+            )
+            raise ValueError(msg)
+        return url
+
+    # Relative path — resolve against the docs base
+    # Strip leading slash if present
+    path = url.lstrip("/")
+    base = QISKIT_DOCS_BASE.rstrip("/")
+    return f"{base}/{path}"
 
 
 async def fetch_text(url: str) -> str | None:
@@ -117,109 +197,79 @@ async def fetch_text_json(url: str) -> list[dict[str, Any]] | None:
         return None
 
 
-async def get_component_docs(component: str) -> dict[str, Any]:
-    """
-    Fetch documentation for a Qiskit SDK module and convert to Markdown.
+async def get_page_docs(url: str, max_length: int = 20000, offset: int = 0) -> dict[str, Any]:
+    """Fetch any Qiskit documentation page and return as markdown.
+
+    Accepts full URLs or relative paths. Validates that the URL is within
+    the allowed documentation domain. Supports pagination for large pages.
 
     Args:
-        component: Module name (e.g., 'circuit', 'primitives', 'transpiler')
+        url: Full URL or relative path (e.g., 'guides/transpile',
+            'api/qiskit/circuit', 'api/qiskit/qiskit.circuit.QuantumCircuit')
+        max_length: Maximum number of characters to return (0 for unlimited)
+        offset: Character offset to start from for pagination
 
     Returns:
-        The documentation content in Markdown format or error status
+        Documentation content in markdown with metadata, or error status
     """
-    if component not in AVAILABLE_MODULES:
-        suggestions = _find_similar(component, AVAILABLE_MODULES)
-        error_response = {
-            "status": "error",
-            "message": f"Module '{component}' not found.",
-            "available_modules": AVAILABLE_MODULES,
-        }
-        if suggestions:
-            error_response["suggestions"] = suggestions
-        return error_response
-
-    url = f"{QISKIT_DOCS_BASE}api/qiskit/{component}"
-    logger.info(f"Fetching component docs for {component} from {url}")
-    html = await fetch_text(url)
-    docs = convert_html_to_markdown(html) if html else None
-
-    if docs is None:
+    try:
+        resolved_url = _resolve_url(url)
+    except ValueError as e:
         return {
             "status": "error",
-            "message": f"Failed to fetch documentation for component '{component}'.",
+            "message": str(e),
         }
+
+    logger.info(f"Fetching page docs from {resolved_url}")
+    html = await fetch_text(resolved_url)
+
+    if html is None:
+        return {
+            "status": "error",
+            "message": (
+                f"Failed to fetch '{url}'. The page may not exist. "
+                "Try using search_docs_tool to find the correct URL."
+            ),
+            "metadata": {
+                "url": resolved_url,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            },
+        }
+
+    docs = convert_html_to_markdown(html)
+
+    # Apply pagination
+    paginated = _truncate_content(docs, max_length=max_length, offset=offset)
 
     return {
         "status": "success",
-        "module": component,
-        "documentation": docs,
+        "url": resolved_url,
+        "documentation": paginated["content"],
+        "has_more": paginated["has_more"],
+        "next_offset": paginated["next_offset"],
+        "total_length": paginated["total_length"],
         "metadata": {
-            "url": url,
+            "url": resolved_url,
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "content_type": "markdown",
-            "content_length": len(docs) if docs else 0,
+            "content_length": len(paginated["content"]),
         },
     }
 
 
-async def get_guide_docs(guide: str) -> dict[str, Any]:
-    """
-    Fetch documentation for a Qiskit guide or best practice and convert to Markdown.
+async def search_qiskit_docs(query: str, scope: str = "all") -> dict[str, Any]:
+    """Search Qiskit documentation for relevant results.
 
     Args:
-        guide: Guide name (e.g., 'quick-start', 'transpile', 'configure-error-mitigation')
-
-    Returns:
-        The documentation content in Markdown format or error status
-    """
-    if guide not in AVAILABLE_GUIDES:
-        suggestions = _find_similar(guide, AVAILABLE_GUIDES)
-        error_response = {
-            "status": "error",
-            "message": f"Guide '{guide}' not found.",
-            "available_guides": AVAILABLE_GUIDES,
-        }
-        if suggestions:
-            error_response["suggestions"] = suggestions
-        return error_response
-
-    url = f"{QISKIT_DOCS_BASE}guides/{guide}"
-    logger.info(f"Fetching style docs for {guide} from {url}")
-    html = await fetch_text(url)
-    docs = convert_html_to_markdown(html) if html else None
-
-    if docs is None:
-        return {
-            "status": "error",
-            "message": f"Failed to fetch documentation for guide '{guide}'.",
-        }
-
-    return {
-        "status": "success",
-        "guide": guide,
-        "documentation": docs,
-        "metadata": {
-            "url": url,
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            "content_type": "markdown",
-            "content_length": len(docs) if docs else 0,
-        },
-    }
-
-
-async def search_qiskit_docs(query: str, module: str = "documentation") -> dict[str, Any]:
-    """
-    Search Qiskit documentation for relevant results.
-
-    Args:
-        query: Search query string (e.g., 'circuit', 'error mitigation')
-        module: Search scope (e.g., 'documentation', 'API')
+        query: Search query string
+        scope: Search scope filter. Valid values (case-sensitive):
+            'all', 'documentation', 'api', 'learning', 'tutorials'
 
     Returns:
         Search results with matching entries, total count, and metadata
     """
-    url = f"{BASE_URL}{SEARCH_PATH}?query={quote(query)}&module={quote(module)}"
-    logger.info(f"Searching docs for '{query}' in module '{module}'")
+    url = f"{BASE_URL}{SEARCH_PATH}?query={quote(query)}&module={quote(scope)}"
+    logger.info(f"Searching docs for '{query}' in scope '{scope}'")
 
     results = await fetch_text_json(url)
 
@@ -233,12 +283,22 @@ async def search_qiskit_docs(query: str, module: str = "documentation") -> dict[
             },
         }
 
+    # Strip HTML tags from search result fields (shallow copy to avoid mutating cached data)
+    cleaned = []
+    for item in results:
+        entry = dict(item)
+        if "title" in entry:
+            entry["title"] = _strip_html_tags(entry["title"])
+        if "text" in entry:
+            entry["text"] = _strip_html_tags(entry["text"])
+        cleaned.append(entry)
+
     return {
         "status": "success",
         "query": query,
-        "module": module,
-        "results": results,
-        "total_results": len(results),
+        "scope": scope,
+        "results": cleaned,
+        "total_results": len(cleaned),
         "metadata": {
             "url": url,
             "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -311,63 +371,36 @@ async def lookup_error_code(code: str) -> dict[str, Any]:
 
 
 def get_list_of_modules() -> dict[str, Any]:
-    """Get list of all Qiskit SDK modules."""
-    return {"status": "success", "modules": AVAILABLE_MODULES}
-
-
-async def get_addon_docs(addon: str) -> dict[str, Any]:
-    """
-    Fetch documentation for a Qiskit addon module and convert to Markdown.
-
-    Args:
-        addon: Addon name (e.g., 'sqd', 'cutting', 'mpf')
-
-    Returns:
-        The documentation content in Markdown format or error status
-    """
-    if addon not in AVAILABLE_ADDONS:
-        suggestions = _find_similar(addon, AVAILABLE_ADDONS)
-        error_response = {
-            "status": "error",
-            "message": f"Addon '{addon}' not found.",
-            "available_addons": AVAILABLE_ADDONS,
-        }
-        if suggestions:
-            error_response["suggestions"] = suggestions
-        return error_response
-
-    url = f"{QISKIT_DOCS_BASE}api/qiskit-addon-{addon}"
-    logger.info(f"Fetching addon docs for {addon} from {url}")
-    html = await fetch_text(url)
-    docs = convert_html_to_markdown(html) if html else None
-
-    if docs is None:
-        return {
-            "status": "error",
-            "message": f"Failed to fetch documentation for addon '{addon}'.",
-        }
-
+    """Get list of all Qiskit SDK modules with descriptions and URL paths."""
     return {
         "status": "success",
-        "addon": addon,
-        "documentation": docs,
-        "metadata": {
-            "url": url,
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            "content_type": "markdown",
-            "content_length": len(docs) if docs else 0,
-        },
+        "modules": [
+            {"name": name, "description": desc, "url_path": f"api/qiskit/{name}"}
+            for name, desc in AVAILABLE_MODULES.items()
+        ],
     }
 
 
 def get_list_of_addons() -> dict[str, Any]:
-    """Get list of all Qiskit addon modules."""
-    return {"status": "success", "addons": AVAILABLE_ADDONS}
+    """Get list of all Qiskit addon modules with descriptions and URL paths."""
+    return {
+        "status": "success",
+        "addons": [
+            {"name": name, "description": desc, "url_path": f"api/qiskit-addon-{name}"}
+            for name, desc in AVAILABLE_ADDONS.items()
+        ],
+    }
 
 
 def get_list_of_guides() -> dict[str, Any]:
-    """Get list of Qiskit guides and best practices."""
-    return {"status": "success", "guides": AVAILABLE_GUIDES}
+    """Get list of Qiskit guides and best practices with descriptions and URL paths."""
+    return {
+        "status": "success",
+        "guides": [
+            {"name": name, "description": desc, "url_path": f"guides/{name}"}
+            for name, desc in AVAILABLE_GUIDES.items()
+        ],
+    }
 
 
 def get_list_of_error_code_categories() -> dict[str, Any]:

--- a/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/server.py
+++ b/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/server.py
@@ -23,13 +23,11 @@ from typing import Any
 from fastmcp import FastMCP
 
 from qiskit_docs_mcp_server.data_fetcher import (
-    get_addon_docs,
-    get_component_docs,
-    get_guide_docs,
     get_list_of_addons,
     get_list_of_error_code_categories,
     get_list_of_guides,
     get_list_of_modules,
+    get_page_docs,
     lookup_error_code,
     search_qiskit_docs,
 )
@@ -52,111 +50,65 @@ logger.info("Qiskit Documentation MCP Server initialized")
 
 
 @mcp.tool()
-async def get_sdk_module_docs_tool(module: str) -> dict[str, Any]:
-    """Get the full API reference documentation for a Qiskit SDK module.
-
-    Returns the complete API reference in markdown format. Responses can be
-    very large (up to 100K+ chars for modules like 'circuit'). Consider using
-    search_docs_tool first to find specific topics, or read the
-    qiskit-docs://modules resource to see all available modules.
-
-    Args:
-        module: Exact module name. Valid values:
-            Circuit construction: 'circuit'
-            Quantum information: 'quantum_info'
-            Transpilation: 'transpiler', 'synthesis', 'dagcircuit',
-                'passmanager', 'converters', 'compiler'
-            Primitives and providers: 'primitives', 'providers'
-            Results and visualization: 'result', 'visualization'
-            Serialization: 'qasm2', 'qasm3', 'qpy'
-            Utilities: 'utils', 'exceptions'
-
-    Returns:
-        Module documentation in markdown format with metadata, or error
-        with fuzzy-match suggestions if the module name is invalid.
-    """
-    return await get_component_docs(module)
-
-
-@mcp.tool()
-async def get_addon_docs_tool(addon: str) -> dict[str, Any]:
-    """Get API documentation for a Qiskit addon package.
-
-    Returns the full API reference for Qiskit addon modules. These are
-    separate packages that extend Qiskit with additional algorithms
-    and capabilities. Read the qiskit-docs://addons resource for the
-    full list with descriptions.
-
-    Args:
-        addon: Exact addon name. Valid values:
-            'aqc-tensor' — Approximate Quantum Compiler with tensor networks
-            'cutting' — Circuit cutting for large circuits
-            'mpf' — Multi-product formulas for Hamiltonian simulation
-            'obp' — Operator backpropagation
-            'sqd' — Sample-based Quantum Diagonalization
-            'utils' — Shared utilities for addon packages
-
-    Returns:
-        Addon API documentation in markdown format with metadata, or error
-        with fuzzy-match suggestions if the addon name is invalid.
-    """
-    return await get_addon_docs(addon)
-
-
-@mcp.tool()
-async def get_guide_tool(guide: str) -> dict[str, Any]:
-    """Get a Qiskit implementation guide or best practice document.
-
-    Returns a complete how-to guide in markdown format. Guides cover
-    practical topics like circuit construction, transpilation, error
-    mitigation, and execution. Read the qiskit-docs://guides resource
-    to see all available guides with descriptions.
-
-    Args:
-        guide: Exact guide slug name. Common guides:
-            Getting started: 'quick-start'
-            Circuits: 'construct-circuits', 'dynamic-circuits'
-            Transpilation: 'transpile', 'transpiler-stages',
-                'transpile-with-pass-managers',
-                'defaults-and-configuration-options'
-            Error handling: 'configure-error-mitigation',
-                'configure-error-suppression',
-                'error-mitigation-and-suppression-techniques'
-            Execution: 'primitives', 'execution-modes',
-                'runtime-options-overview'
-            Functions: 'functions', 'ibm-circuit-function'
-
-    Returns:
-        Guide documentation in markdown format with metadata, or error
-        with fuzzy-match suggestions if the guide name is invalid.
-    """
-    return await get_guide_docs(guide)
-
-
-@mcp.tool()
-async def search_docs_tool(query: str, module: str = "documentation") -> dict[str, Any]:
+async def search_docs_tool(query: str, scope: str = "all") -> dict[str, Any]:
     """Search across the entire Qiskit documentation for relevant content.
 
-    Use this tool as a starting point when you're not sure which specific
-    module or guide to fetch. Returns ranked results with titles, URLs,
-    sections, and text snippets.
+    Use this as the primary entry point to discover documentation pages.
+    Returns ranked results with titles, URLs, sections, and text snippets.
+    Use get_page_tool to fetch the full content of any result URL.
 
     Args:
-        query: Search query string (e.g., 'error mitigation',
-            'QuantumCircuit', 'transpiler optimization'). More specific
-            queries yield better results.
-        module: Search scope filter (case-sensitive). Valid values:
-            'all' — Search everything
-            'documentation' — Guides and general docs (default)
+        query: Search query string (e.g., 'error mitigation', 'QuantumCircuit',
+            'transpiler optimization'). More specific queries yield better results.
+        scope: Search scope filter (case-sensitive). Valid values:
+            'all' — Search everything (default)
+            'documentation' — Guides and general docs
             'api' — API reference pages only
             'learning' — Learning resources and tutorials
             'tutorials' — Tutorial content only
 
     Returns:
-        List of matching documentation entries with URLs, titles,
-        sections, and text snippets.
+        List of matching documentation entries with URLs, titles, sections,
+        and text snippets. Use the URLs with get_page_tool to fetch full content.
     """
-    return await search_qiskit_docs(query, module)
+    return await search_qiskit_docs(query, scope)
+
+
+@mcp.tool()
+async def get_page_tool(
+    url: str,
+    max_length: int = 20000,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """Fetch a Qiskit documentation page and return its content as markdown.
+
+    Accepts any URL from the Qiskit documentation site. Use search_docs_tool
+    first to find the right page, or use URLs from the resource lists.
+
+    Returns documentation in markdown format with pagination support.
+    Default max_length is 20000 chars. Set max_length=0 for unlimited.
+    Use offset to retrieve subsequent pages when has_more is true.
+
+    This tool can fetch ANY page in the Qiskit documentation, including:
+    - SDK module API references (e.g., 'api/qiskit/circuit')
+    - Individual class pages (e.g., 'api/qiskit/qiskit.circuit.QuantumCircuit')
+    - Addon documentation (e.g., 'api/qiskit-addon-sqd')
+    - Implementation guides (e.g., 'guides/transpile')
+    - Any other documentation page
+
+    Args:
+        url: Documentation page URL. Accepts:
+            - Full URL: 'https://quantum.cloud.ibm.com/docs/guides/transpile'
+            - Relative path: 'guides/transpile', 'api/qiskit/circuit'
+        max_length: Maximum characters to return (default: 20000, 0 for unlimited)
+        offset: Character offset for pagination (default: 0)
+
+    Returns:
+        Page content in markdown format with pagination metadata
+        (has_more, next_offset, total_length), or error with suggestion
+        to use search_docs_tool if the page is not found.
+    """
+    return await get_page_docs(url, max_length=max_length, offset=offset)
 
 
 @mcp.tool()
@@ -168,7 +120,7 @@ async def lookup_error_code_tool(code: str) -> dict[str, Any]:
     Read the qiskit-docs://error-codes resource for error code categories.
 
     Error code ranges:
-        1XXX: Validation, transpilation, backend, authorization
+        1XXX: Validation, transpilation, backend, authorization, job management
         2XXX: Backend configuration, booking, data retrieval
         3XXX: Job handling, authentication, analytics
         4XXX: Session management and job limits
@@ -179,12 +131,12 @@ async def lookup_error_code_tool(code: str) -> dict[str, Any]:
         9XXX: Hardware loading and internal errors
 
     Args:
-        code: 4-digit numeric error code as a string (e.g., '1002',
-            '7001', '8004'). Must be exactly 4 digits.
+        code: 4-digit numeric error code as a string (e.g., '1002', '7001').
+            Must be exactly 4 digits.
 
     Returns:
-        Error code details including message, solution, and link to
-        the error registry. Returns error if code is invalid or not found.
+        Error code details including message, solution, and link to the
+        error registry. Returns error if code format is invalid or not found.
     """
     return await lookup_error_code(code)
 
@@ -197,19 +149,33 @@ async def lookup_error_code_tool(code: str) -> dict[str, Any]:
 
 @mcp.resource("qiskit-docs://modules", mime_type="application/json")
 def modules_resource() -> dict[str, Any]:
-    """Get list of all Qiskit SDK modules."""
+    """Get list of all Qiskit SDK modules with URL paths.
+
+    Returns curated list of common SDK modules. Use get_page_tool with
+    'api/qiskit/{module}' to fetch documentation, or search_docs_tool
+    to discover any module page.
+    """
     return get_list_of_modules()
 
 
 @mcp.resource("qiskit-docs://addons", mime_type="application/json")
 def addons_resource() -> dict[str, Any]:
-    """Get list of all Qiskit addon modules."""
+    """Get list of Qiskit addon packages with URL paths.
+
+    Returns curated list of addon packages. Use get_page_tool with
+    'api/qiskit-addon-{name}' to fetch documentation.
+    """
     return get_list_of_addons()
 
 
 @mcp.resource("qiskit-docs://guides", mime_type="application/json")
 def guides_resource() -> dict[str, Any]:
-    """Get list of Qiskit guides and best practices."""
+    """Get list of Qiskit implementation guides with URL paths.
+
+    Returns curated list of common guides. Use get_page_tool with
+    'guides/{name}' to fetch documentation, or search_docs_tool to
+    discover any guide.
+    """
     return get_list_of_guides()
 
 

--- a/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/server.py
+++ b/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/server.py
@@ -53,71 +53,138 @@ logger.info("Qiskit Documentation MCP Server initialized")
 
 @mcp.tool()
 async def get_sdk_module_docs_tool(module: str) -> dict[str, Any]:
-    """
-    Get documentation for a Qiskit SDK module.
+    """Get the full API reference documentation for a Qiskit SDK module.
+
+    Returns the complete API reference in markdown format. Responses can be
+    very large (up to 100K+ chars for modules like 'circuit'). Consider using
+    search_docs_tool first to find specific topics, or read the
+    qiskit-docs://modules resource to see all available modules.
 
     Args:
-        module: Module name (e.g., 'circuit', 'primitives', 'transpiler', 'quantum_info')
+        module: Exact module name. Valid values:
+            Circuit construction: 'circuit'
+            Quantum information: 'quantum_info'
+            Transpilation: 'transpiler', 'synthesis', 'dagcircuit',
+                'passmanager', 'converters', 'compiler'
+            Primitives and providers: 'primitives', 'providers'
+            Results and visualization: 'result', 'visualization'
+            Serialization: 'qasm2', 'qasm3', 'qpy'
+            Utilities: 'utils', 'exceptions'
 
     Returns:
-        Module documentation including API reference and usage examples.
+        Module documentation in markdown format with metadata, or error
+        with fuzzy-match suggestions if the module name is invalid.
     """
     return await get_component_docs(module)
 
 
 @mcp.tool()
 async def get_addon_docs_tool(addon: str) -> dict[str, Any]:
-    """
-    Get documentation for a Qiskit addon module.
+    """Get API documentation for a Qiskit addon package.
+
+    Returns the full API reference for Qiskit addon modules. These are
+    separate packages that extend Qiskit with additional algorithms
+    and capabilities. Read the qiskit-docs://addons resource for the
+    full list with descriptions.
 
     Args:
-        addon: Addon name (e.g., 'sqd', 'cutting', 'mpf', 'obp', 'aqc-tensor')
+        addon: Exact addon name. Valid values:
+            'aqc-tensor' — Approximate Quantum Compiler with tensor networks
+            'cutting' — Circuit cutting for large circuits
+            'mpf' — Multi-product formulas for Hamiltonian simulation
+            'obp' — Operator backpropagation
+            'sqd' — Sample-based Quantum Diagonalization
+            'utils' — Shared utilities for addon packages
 
     Returns:
-        Addon API documentation including classes, methods, and usage examples.
+        Addon API documentation in markdown format with metadata, or error
+        with fuzzy-match suggestions if the addon name is invalid.
     """
     return await get_addon_docs(addon)
 
 
 @mcp.tool()
 async def get_guide_tool(guide: str) -> dict[str, Any]:
-    """
-    Get a Qiskit guide or best practice documentation.
+    """Get a Qiskit implementation guide or best practice document.
+
+    Returns a complete how-to guide in markdown format. Guides cover
+    practical topics like circuit construction, transpilation, error
+    mitigation, and execution. Read the qiskit-docs://guides resource
+    to see all available guides with descriptions.
 
     Args:
-        guide: Guide name (e.g., 'quick-start', 'transpile', 'configure-error-mitigation', 'dynamic-circuits')
+        guide: Exact guide slug name. Common guides:
+            Getting started: 'quick-start'
+            Circuits: 'construct-circuits', 'dynamic-circuits'
+            Transpilation: 'transpile', 'transpiler-stages',
+                'transpile-with-pass-managers',
+                'defaults-and-configuration-options'
+            Error handling: 'configure-error-mitigation',
+                'configure-error-suppression',
+                'error-mitigation-and-suppression-techniques'
+            Execution: 'primitives', 'execution-modes',
+                'runtime-options-overview'
+            Functions: 'functions', 'ibm-circuit-function'
 
     Returns:
-        Complete guide documentation with best practices and implementation patterns.
+        Guide documentation in markdown format with metadata, or error
+        with fuzzy-match suggestions if the guide name is invalid.
     """
     return await get_guide_docs(guide)
 
 
 @mcp.tool()
 async def search_docs_tool(query: str, module: str = "documentation") -> dict[str, Any]:
-    """
-    Search Qiskit documentation for relevant modules, addons, and guides.
+    """Search across the entire Qiskit documentation for relevant content.
+
+    Use this tool as a starting point when you're not sure which specific
+    module or guide to fetch. Returns ranked results with titles, URLs,
+    sections, and text snippets.
 
     Args:
-        query: Search query (e.g., 'optimization', 'circuit', 'error')
-        module: Search module (e.g. 'documentation', 'API' etc)
+        query: Search query string (e.g., 'error mitigation',
+            'QuantumCircuit', 'transpiler optimization'). More specific
+            queries yield better results.
+        module: Search scope filter (case-sensitive). Valid values:
+            'all' — Search everything
+            'documentation' — Guides and general docs (default)
+            'api' — API reference pages only
+            'learning' — Learning resources and tutorials
+            'tutorials' — Tutorial content only
 
     Returns:
-        List of matching documentation entries with URLs and types.
+        List of matching documentation entries with URLs, titles,
+        sections, and text snippets.
     """
     return await search_qiskit_docs(query, module)
 
 
 @mcp.tool()
 async def lookup_error_code_tool(code: str) -> dict[str, Any]:
-    """
-    Look up a Qiskit/IBM Quantum error code to get its message and solution.
+    """Look up a Qiskit or IBM Quantum error code to get its description and solution.
+
+    Use this when a user encounters a numeric error code from Qiskit or
+    IBM Quantum services. Returns the error message and suggested fix.
+    Read the qiskit-docs://error-codes resource for error code categories.
+
+    Error code ranges:
+        1XXX: Validation, transpilation, backend, authorization
+        2XXX: Backend configuration, booking, data retrieval
+        3XXX: Job handling, authentication, analytics
+        4XXX: Session management and job limits
+        5XXX: Job timeout and cancellation
+        6XXX: Shot limits, compiler input, control system
+        7XXX: Instruction and basis gate compatibility
+        8XXX: Pulse and channel configuration
+        9XXX: Hardware loading and internal errors
 
     Args:
-        code: 4-digit error code (e.g., '1002', '7001', '8004')
+        code: 4-digit numeric error code as a string (e.g., '1002',
+            '7001', '8004'). Must be exactly 4 digits.
 
     Returns:
-        Error code details including message and suggested solution.
+        Error code details including message, solution, and link to
+        the error registry. Returns error if code is invalid or not found.
     """
     return await lookup_error_code(code)
 

--- a/qiskit-docs-mcp-server/tests/test_data_fetcher.py
+++ b/qiskit-docs-mcp-server/tests/test_data_fetcher.py
@@ -15,24 +15,26 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
+import pytest
 from qiskit_docs_mcp_server.constants import (
     AVAILABLE_ADDONS,
+    AVAILABLE_GUIDES,
     AVAILABLE_MODULES,
     HTTP_TIMEOUT,
     _get_env_float,
 )
 from qiskit_docs_mcp_server.data_fetcher import (
-    _find_similar,
+    _resolve_url,
+    _strip_html_tags,
+    _truncate_content,
     convert_html_to_markdown,
     fetch_text,
     fetch_text_json,
-    get_addon_docs,
-    get_component_docs,
-    get_guide_docs,
     get_list_of_addons,
     get_list_of_error_code_categories,
     get_list_of_guides,
     get_list_of_modules,
+    get_page_docs,
     lookup_error_code,
     search_qiskit_docs,
 )
@@ -132,281 +134,435 @@ class TestFetchTextJson:
         assert isinstance(result, list)
 
 
-class TestGetComponentDocs:
-    """Test get_component_docs function."""
+class TestResolveUrl:
+    """Test URL resolution and validation."""
+
+    def test_resolve_relative_path(self):
+        """Test resolving a relative path."""
+        url = _resolve_url("guides/transpile")
+        assert url == "https://quantum.cloud.ibm.com/docs/guides/transpile"
+
+    def test_resolve_relative_path_with_leading_slash(self):
+        """Test resolving a relative path with leading slash."""
+        url = _resolve_url("/guides/transpile")
+        assert url == "https://quantum.cloud.ibm.com/docs/guides/transpile"
+
+    def test_resolve_api_path(self):
+        """Test resolving an API path."""
+        url = _resolve_url("api/qiskit/circuit")
+        assert url == "https://quantum.cloud.ibm.com/docs/api/qiskit/circuit"
+
+    def test_resolve_class_path(self):
+        """Test resolving a class-level API path."""
+        url = _resolve_url("api/qiskit/qiskit.circuit.QuantumCircuit")
+        assert "qiskit.circuit.QuantumCircuit" in url
+
+    def test_full_url_allowed_domain(self):
+        """Test that full URLs with allowed domain pass through."""
+        url = _resolve_url("https://quantum.cloud.ibm.com/docs/guides/transpile")
+        assert url == "https://quantum.cloud.ibm.com/docs/guides/transpile"
+
+    def test_full_url_disallowed_domain(self):
+        """Test that URLs with disallowed domains raise ValueError."""
+        with pytest.raises(ValueError, match="not allowed"):
+            _resolve_url("https://evil.com/malicious")
+
+    def test_resolve_addon_path(self):
+        """Test resolving an addon path."""
+        url = _resolve_url("api/qiskit-addon-sqd")
+        assert url == "https://quantum.cloud.ibm.com/docs/api/qiskit-addon-sqd"
+
+    def test_resolve_empty_string(self):
+        """Test resolving an empty string returns base URL."""
+        url = _resolve_url("")
+        assert url == "https://quantum.cloud.ibm.com/docs/"
+
+
+class TestGetPageDocs:
+    """Test get_page_docs function."""
 
     @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_component_docs_valid_module(self, mock_fetch):
-        """Test getting docs for a valid module."""
-        mock_fetch.return_value = "Circuit documentation"
-        result = await get_component_docs("circuit")
-
+    async def test_get_page_relative_path(self, mock_fetch):
+        """Test fetching a page by relative path."""
+        mock_fetch.return_value = "<h1>Circuit</h1><p>Documentation</p>"
+        result = await get_page_docs("api/qiskit/circuit")
         assert result["status"] == "success"
-        assert result["module"] == "circuit"
+        assert "documentation" in result
         assert "metadata" in result
-        mock_fetch.assert_called_once()
+        assert "Circuit" in result["documentation"]
 
     @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_component_docs_invalid_module(self, mock_fetch):
-        """Test getting docs for an invalid module."""
-        result = await get_component_docs("invalid_module")
-        assert result["status"] == "error"
-        assert "not found" in result["message"]
-        assert "available_modules" in result
-        mock_fetch.assert_not_called()
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_component_docs_invalid_with_suggestions(self, mock_fetch):
-        """Test getting docs with similar module suggestions."""
-        result = await get_component_docs("circuitt")  # Typo of 'circuit'
-        assert result["status"] == "error"
-        assert "available_modules" in result
-        # May or may not have suggestions depending on similarity cutoff
-        if "suggestions" in result:
-            assert "circuit" in result["suggestions"]
-        mock_fetch.assert_not_called()
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_component_docs_all_valid_modules(self, mock_fetch):
-        """Test getting docs for all valid modules."""
-        mock_fetch.return_value = "Documentation"
-
-        for module in AVAILABLE_MODULES:
-            result = await get_component_docs(module)
-            assert result["status"] == "success"
-            assert result["module"] == module
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_component_docs_fetch_fails(self, mock_fetch):
-        """Test get_component_docs when fetch fails."""
-        mock_fetch.return_value = None
-        result = await get_component_docs("circuit")
-        assert result["status"] == "error"
-
-
-class TestGetGuideDocs:
-    """Test get_guide_docs function."""
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_guide_docs_valid_guide(self, mock_fetch):
-        """Test getting docs for a valid guide."""
-        mock_fetch.return_value = "Quick start guide"
-        result = await get_guide_docs("quick-start")
-
+    async def test_get_page_full_url(self, mock_fetch):
+        """Test fetching a page by full URL."""
+        mock_fetch.return_value = "<h1>Guide</h1>"
+        result = await get_page_docs("https://quantum.cloud.ibm.com/docs/guides/transpile")
         assert result["status"] == "success"
-        assert result["guide"] == "quick-start"
+
+    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
+    async def test_get_page_fetch_fails(self, mock_fetch):
+        """Test get_page when fetch fails."""
+        mock_fetch.return_value = None
+        result = await get_page_docs("api/qiskit/nonexistent")
+        assert result["status"] == "error"
+        assert "search_docs_tool" in result["message"]
+
+    async def test_get_page_disallowed_domain(self):
+        """Test get_page rejects disallowed domains."""
+        result = await get_page_docs("https://evil.com/page")
+        assert result["status"] == "error"
+        assert "not allowed" in result["message"]
+
+    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
+    async def test_get_page_has_metadata(self, mock_fetch):
+        """Test that get_page response includes metadata."""
+        mock_fetch.return_value = "<p>Content</p>"
+        result = await get_page_docs("guides/quick-start")
         assert "metadata" in result
-        mock_fetch.assert_called_once()
+        assert "url" in result["metadata"]
+        assert "timestamp" in result["metadata"]
 
     @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_guide_docs_invalid_guide(self, mock_fetch):
-        """Test getting docs for an invalid guide."""
-        result = await get_guide_docs("nonexistent-guide")
-        assert result["status"] == "error"
-        assert "not found" in result["message"]
-        assert "available_guides" in result
-        mock_fetch.assert_not_called()
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_guide_docs_invalid_with_suggestions(self, mock_fetch):
-        """Test getting docs with similar guide suggestions."""
-        result = await get_guide_docs(
-            "transpile-with-pass-manager"
-        )  # Similar to 'transpile-with-pass-managers'
-        assert result["status"] == "error"
-        assert "available_guides" in result
-        # May or may not have suggestions depending on similarity cutoff
-        if "suggestions" in result:
-            assert "transpile-with-pass-managers" in result["suggestions"]
-        mock_fetch.assert_not_called()
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_guide_docs_all_valid_guides(self, mock_fetch):
-        """Test getting docs for all valid guides."""
-        mock_fetch.return_value = "Guide documentation"
-        valid_guides = [
-            "quick-start",
-            "construct-circuits",
-            "transpile",
-            "dynamic-circuits",
-            "primitives",
-            "configure-error-mitigation",
-        ]
-
-        for guide in valid_guides:
-            result = await get_guide_docs(guide)
-            assert result["status"] == "success"
-            assert result["guide"] == guide
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_guide_docs_fetch_fails(self, mock_fetch):
-        """Test get_guide_docs when fetch fails."""
-        mock_fetch.return_value = None
-        result = await get_guide_docs("quick-start")
-        assert result["status"] == "error"
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_guide_docs_error_mitigation(self, mock_fetch):
-        """Test getting error-mitigation guide."""
-        mock_fetch.return_value = "Error mitigation techniques"
-        result = await get_guide_docs("configure-error-mitigation")
+    async def test_get_page_pagination_has_more(self, mock_fetch):
+        """Test that get_page_docs returns pagination fields."""
+        mock_fetch.return_value = "<p>" + "x" * 50000 + "</p>"
+        result = await get_page_docs("api/qiskit/circuit", max_length=1000)
         assert result["status"] == "success"
-        assert result["guide"] == "configure-error-mitigation"
+        assert result["has_more"] is True
+        assert result["next_offset"] is not None
+        assert result["total_length"] > 1000
+
+    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
+    async def test_get_page_pagination_with_offset(self, mock_fetch):
+        """Test pagination with offset retrieves subsequent content."""
+        mock_fetch.return_value = "<p>" + "A" * 100 + "</p>"
+        result = await get_page_docs("api/qiskit/circuit", max_length=50, offset=10)
+        assert result["status"] == "success"
+        assert "has_more" in result
+
+    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
+    async def test_get_page_unlimited_length(self, mock_fetch):
+        """Test max_length=0 returns all content without truncation."""
+        mock_fetch.return_value = "<p>" + "y" * 50000 + "</p>"
+        result = await get_page_docs("api/qiskit/circuit", max_length=0)
+        assert result["status"] == "success"
+        assert result["has_more"] is False
+
+
+class TestTruncateContent:
+    """Test _truncate_content function."""
+
+    def test_short_content_no_truncation(self):
+        """Test that short content is not truncated."""
+        result = _truncate_content("hello world", max_length=100)
+        assert result["content"] == "hello world"
+        assert result["has_more"] is False
+        assert result["next_offset"] is None
+
+    def test_long_content_truncated(self):
+        """Test that content exceeding max_length is truncated."""
+        content = "a" * 200
+        result = _truncate_content(content, max_length=100)
+        assert len(result["content"]) <= 100
+        assert result["has_more"] is True
+        assert result["next_offset"] is not None
+        assert result["total_length"] == 200
+
+    def test_offset_skips_content(self):
+        """Test that offset skips the beginning of content."""
+        content = "0123456789"
+        result = _truncate_content(content, max_length=100, offset=5)
+        assert result["content"] == "56789"
+        assert result["has_more"] is False
+
+    def test_unlimited_returns_all(self):
+        """Test max_length=0 returns all content."""
+        content = "a" * 50000
+        result = _truncate_content(content, max_length=0)
+        assert result["content"] == content
+        assert result["has_more"] is False
+
+    def test_negative_offset_clamped_to_zero(self):
+        """Test that negative offset is clamped to 0."""
+        result = _truncate_content("hello", max_length=100, offset=-5)
+        assert result["content"] == "hello"
+        assert result["offset"] == 0
+
+    def test_negative_max_length_treated_as_unlimited(self):
+        """Test that negative max_length is treated as unlimited (clamped to 0)."""
+        content = "a" * 500
+        result = _truncate_content(content, max_length=-10)
+        assert result["content"] == content
+        assert result["has_more"] is False
+
+    def test_truncation_snaps_to_line_boundary(self):
+        """Test that truncation snaps to a nearby newline boundary."""
+        lines = "\n".join(["line " + str(i) for i in range(50)])
+        result = _truncate_content(lines, max_length=100)
+        assert result["content"].endswith("\n")
+        assert result["has_more"] is True
+
+
+class TestStripHtmlTags:
+    """Test HTML tag stripping."""
+
+    def test_strip_em_tags(self):
+        """Test stripping em tags."""
+        assert _strip_html_tags("<em>Transpiler</em> stages") == "Transpiler stages"
+
+    def test_strip_multiple_tags(self):
+        """Test stripping multiple tags."""
+        assert _strip_html_tags("<em>error</em> <strong>mitigation</strong>") == "error mitigation"
+
+    def test_no_tags(self):
+        """Test string without tags."""
+        assert _strip_html_tags("plain text") == "plain text"
+
+    def test_empty_string(self):
+        """Test empty string."""
+        assert _strip_html_tags("") == ""
 
 
 class TestSearchQiskitDocs:
     """Test search_qiskit_docs function."""
 
     @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text_json")
-    async def test_search_qiskit_docs_with_results(self, mock_fetch):
+    async def test_search_with_results(self, mock_fetch):
         """Test search with results."""
         mock_fetch.return_value = [
-            {"name": "circuit", "type": "module"},
-            {"name": "optimization", "type": "guide"},
+            {"title": "Circuit", "url": "/docs/api/qiskit/circuit"},
         ]
         result = await search_qiskit_docs("circuit")
-
         assert result["status"] == "success"
         assert result["query"] == "circuit"
-        assert len(result["results"]) == 2
-        assert result["total_results"] == 2
-        assert "metadata" in result
-        mock_fetch.assert_called_once()
+        assert len(result["results"]) == 1
+        assert result["total_results"] == 1
 
     @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text_json")
-    async def test_search_qiskit_docs_no_results(self, mock_fetch):
+    async def test_search_no_results(self, mock_fetch):
         """Test search with no results."""
         mock_fetch.return_value = []
         result = await search_qiskit_docs("nonexistent")
-
         assert result["status"] == "success"
-        assert result["query"] == "nonexistent"
         assert result["results"] == []
         assert result["total_results"] == 0
 
     @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text_json")
-    async def test_search_qiskit_docs_returns_dict(self, mock_fetch):
-        """Test that search returns a dict with proper structure."""
-        mock_fetch.return_value = [{"result": "test"}]
-        result = await search_qiskit_docs("test")
-        assert isinstance(result, dict)
-        assert "status" in result
-        assert "results" in result
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text_json")
-    async def test_search_qiskit_docs_fetch_fails(self, mock_fetch):
-        """Test search when fetch fails returns error status."""
+    async def test_search_fetch_fails(self, mock_fetch):
+        """Test search when fetch fails."""
         mock_fetch.return_value = None
         result = await search_qiskit_docs("circuit")
         assert result["status"] == "error"
-        assert "Failed to search" in result["message"]
 
     @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text_json")
-    async def test_search_qiskit_docs_empty_results(self, mock_fetch):
-        """Test search with empty results list."""
+    async def test_search_strips_html_tags(self, mock_fetch):
+        """Test that HTML tags are stripped from search results."""
+        mock_fetch.return_value = [
+            {
+                "title": "<em>Transpiler</em> options",
+                "text": "<em>Transpiler</em> passes",
+            },
+        ]
+        result = await search_qiskit_docs("transpiler")
+        assert result["results"][0]["title"] == "Transpiler options"
+        assert result["results"][0]["text"] == "Transpiler passes"
+
+    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text_json")
+    async def test_search_uses_scope_param(self, mock_fetch):
+        """Test that scope parameter is passed to API."""
         mock_fetch.return_value = []
-        result = await search_qiskit_docs("nonexistent")
-        assert result["status"] == "success"
-        assert result["results"] == []
-        assert result["total_results"] == 0
+        await search_qiskit_docs("test", scope="api")
+        call_url = mock_fetch.call_args[0][0]
+        assert "module=api" in call_url
 
     @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text_json")
-    async def test_search_qiskit_docs_url_encodes_query(self, mock_fetch):
+    async def test_search_default_scope_is_all(self, mock_fetch):
+        """Test that default scope is 'all'."""
+        mock_fetch.return_value = []
+        await search_qiskit_docs("test")
+        call_url = mock_fetch.call_args[0][0]
+        assert "module=all" in call_url
+
+    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text_json")
+    async def test_search_url_encodes_query(self, mock_fetch):
         """Test that search query is URL-encoded."""
         mock_fetch.return_value = []
         await search_qiskit_docs("error mitigation")
         call_url = mock_fetch.call_args[0][0]
         assert "error%20mitigation" in call_url
 
-
-class TestFuzzyMatching:
-    """Test fuzzy matching functionality."""
-
-    def test_find_similar_exact_match(self):
-        """Test finding exact match."""
-        available = ["circuit", "primitives", "transpiler"]
-        result = _find_similar("circuit", available)
-        assert "circuit" in result
-
-    def test_find_similar_typo_match(self):
-        """Test finding close match with typo."""
-        available = ["circuit", "primitives", "transpiler"]
-        result = _find_similar("circuitt", available)
-        assert "circuit" in result
-
-    def test_find_similar_no_match(self):
-        """Test no match returns empty list."""
-        available = ["circuit", "primitives", "transpiler"]
-        result = _find_similar("xyz123", available)
-        assert len(result) == 0
-
-    def test_find_similar_empty_available(self):
-        """Test with empty available list."""
-        result = _find_similar("circuit", [])
-        assert result == []
-
-    def test_find_similar_empty_query(self):
-        """Test with empty query."""
-        available = ["circuit", "primitives", "transpiler"]
-        result = _find_similar("", available)
-        assert result == []
-
-    def test_find_similar_partial_match(self):
-        """Test finding partial matches."""
-        available = ["optimization", "quantum-circuits", "error-mitigation"]
-        # Test with a query that should match "error-mitigation"
-        result = _find_similar("error", available, cutoff=0.5)
-        assert isinstance(result, list)
-        # May or may not have matches depending on similarity
-
-    def test_find_similar_limit_results(self):
-        """Test that results are limited to 3."""
-        available = ["circuit", "circuits", "circuitry", "circular", "circulate"]
-        result = _find_similar("circuit", available)
-        # difflib.get_close_matches returns at most n=3 by default
-        assert len(result) <= 3
-
-
-class TestMetadataHandling:
-    """Test metadata functionality."""
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_component_docs_has_metadata(self, mock_fetch):
-        """Test that component docs response includes metadata."""
-        mock_fetch.return_value = "Documentation"
-        result = await get_component_docs("circuit")
-
-        assert "metadata" in result
-        metadata = result["metadata"]
-        assert "url" in metadata
-        assert "timestamp" in metadata
-        assert "content_type" in metadata
-        assert "content_length" in metadata
-        assert metadata["content_type"] == "markdown"
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_guide_docs_has_metadata(self, mock_fetch):
-        """Test that guide docs response includes metadata."""
-        mock_fetch.return_value = "Guide content"
-        result = await get_guide_docs("quick-start")
-
-        assert "metadata" in result
-        metadata = result["metadata"]
-        assert "url" in metadata
-        assert "timestamp" in metadata
-        assert metadata["content_type"] == "markdown"
-
     @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text_json")
-    async def test_search_docs_has_metadata(self, mock_fetch):
-        """Test that search docs response includes metadata."""
-        mock_fetch.return_value = [{"name": "circuit"}]
+    async def test_search_results_missing_title_text_keys(self, mock_fetch):
+        """Test that search results without title/text keys don't error."""
+        mock_fetch.return_value = [
+            {"url": "/docs/api/qiskit/circuit"},
+        ]
         result = await search_qiskit_docs("circuit")
+        assert result["status"] == "success"
+        assert len(result["results"]) == 1
 
-        assert "metadata" in result
-        metadata = result["metadata"]
-        assert "url" in metadata
-        assert "timestamp" in metadata
-        assert metadata["content_type"] == "json"
+
+class TestLookupErrorCode:
+    """Test lookup_error_code function."""
+
+    async def test_invalid_code_format_letters(self):
+        """Test that non-numeric codes return an error."""
+        result = await lookup_error_code("abcd")
+        assert result["status"] == "error"
+        assert "Invalid error code format" in result["message"]
+
+    async def test_invalid_code_format_short(self):
+        """Test that codes with wrong length return an error."""
+        result = await lookup_error_code("12")
+        assert result["status"] == "error"
+
+    async def test_invalid_code_format_long(self):
+        """Test that 5-digit codes return an error."""
+        result = await lookup_error_code("12345")
+        assert result["status"] == "error"
+
+    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
+    async def test_fetch_failure(self, mock_fetch):
+        """Test lookup when fetch fails."""
+        mock_fetch.return_value = None
+        result = await lookup_error_code("1002")
+        assert result["status"] == "error"
+
+    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
+    async def test_code_found(self, mock_fetch):
+        """Test successful error code lookup."""
+        mock_fetch.return_value = (
+            "<table><tr><td>1002</td>"
+            "<td>Error in the validation process.</td>"
+            "<td>Check the job.</td></tr></table>"
+        )
+        result = await lookup_error_code("1002")
+        assert result["status"] == "success"
+        assert result["code"] == "1002"
+        assert "1002" in result["details"]
+
+    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
+    async def test_code_not_found(self, mock_fetch):
+        """Test lookup for a code that does not exist."""
+        mock_fetch.return_value = "<table><tr><td>1002</td><td>Some error</td></tr></table>"
+        result = await lookup_error_code("9999")
+        assert result["status"] == "error"
+        assert "not found" in result["message"]
+
+
+class TestConvertHtmlToMarkdown:
+    """Test convert_html_to_markdown function."""
+
+    def test_basic_html(self):
+        """Test conversion of basic HTML."""
+        html = "<h1>Title</h1><p>Paragraph text.</p>"
+        result = convert_html_to_markdown(html)
+        assert "Title" in result
+        assert "Paragraph text." in result
+
+    def test_links_preserved(self):
+        """Test that links are preserved."""
+        html = '<a href="https://example.com">Click here</a>'
+        result = convert_html_to_markdown(html)
+        assert "https://example.com" in result
+
+    def test_empty_html(self):
+        """Test conversion of empty HTML."""
+        result = convert_html_to_markdown("")
+        assert result.strip() == ""
+
+
+class TestListHelpers:
+    """Test list helper functions."""
+
+    def test_get_list_of_modules(self):
+        """Test get_list_of_modules returns correct structure with url_path."""
+        result = get_list_of_modules()
+        assert result["status"] == "success"
+        assert "modules" in result
+        assert isinstance(result["modules"], list)
+        assert len(result["modules"]) > 0
+        # Check structure includes name, description, url_path
+        first = result["modules"][0]
+        assert "name" in first
+        assert "description" in first
+        assert "url_path" in first
+        assert first["url_path"].startswith("api/qiskit/")
+
+    def test_get_list_of_addons(self):
+        """Test get_list_of_addons returns correct structure with url_path."""
+        result = get_list_of_addons()
+        assert result["status"] == "success"
+        assert "addons" in result
+        assert len(result["addons"]) > 0
+        first = result["addons"][0]
+        assert "name" in first
+        assert "description" in first
+        assert "url_path" in first
+        assert "qiskit-addon-" in first["url_path"]
+
+    def test_get_list_of_guides(self):
+        """Test get_list_of_guides returns correct structure with url_path."""
+        result = get_list_of_guides()
+        assert result["status"] == "success"
+        assert "guides" in result
+        assert len(result["guides"]) > 0
+        first = result["guides"][0]
+        assert "name" in first
+        assert "description" in first
+        assert "url_path" in first
+        assert first["url_path"].startswith("guides/")
+
+    def test_get_list_of_error_code_categories(self):
+        """Test get_list_of_error_code_categories returns correct structure."""
+        result = get_list_of_error_code_categories()
+        assert result["status"] == "success"
+        assert "categories" in result
+        assert isinstance(result["categories"], dict)
+        assert "registry_url" in result
+
+
+class TestDocFetcherConstants:
+    """Test data_fetcher constants."""
+
+    def test_qiskit_modules_not_empty(self):
+        """Test that AVAILABLE_MODULES is not empty."""
+        assert len(AVAILABLE_MODULES) > 0
+
+    def test_qiskit_modules_has_circuit(self):
+        """Test that AVAILABLE_MODULES contains circuit."""
+        assert "circuit" in AVAILABLE_MODULES
+
+    def test_qiskit_modules_are_dict_with_descriptions(self):
+        """Test that AVAILABLE_MODULES values are description strings."""
+        assert isinstance(AVAILABLE_MODULES, dict)
+        for key, value in AVAILABLE_MODULES.items():
+            assert isinstance(key, str)
+            assert isinstance(value, str)
+            assert len(value) > 0
+
+    def test_qiskit_addon_modules_not_empty(self):
+        """Test that AVAILABLE_ADDONS is not empty."""
+        assert len(AVAILABLE_ADDONS) > 0
+
+    def test_qiskit_addons_are_dict_with_descriptions(self):
+        """Test that AVAILABLE_ADDONS values are description strings."""
+        assert isinstance(AVAILABLE_ADDONS, dict)
+        for key, value in AVAILABLE_ADDONS.items():
+            assert isinstance(key, str)
+            assert isinstance(value, str)
+            assert len(value) > 0
+
+    def test_qiskit_guides_not_empty(self):
+        """Test that AVAILABLE_GUIDES is not empty."""
+        assert len(AVAILABLE_GUIDES) > 0
+
+    def test_qiskit_guides_are_dict_with_descriptions(self):
+        """Test that AVAILABLE_GUIDES values are description strings."""
+        assert isinstance(AVAILABLE_GUIDES, dict)
+        for key, value in AVAILABLE_GUIDES.items():
+            assert isinstance(key, str)
+            assert isinstance(value, str)
+            assert len(value) > 0
 
 
 class TestEnvironmentConfiguration:
@@ -450,272 +606,4 @@ class TestEnvironmentConfiguration:
     def test_http_timeout_default(self):
         """Test that HTTP_TIMEOUT has a reasonable default."""
         assert HTTP_TIMEOUT > 0
-        assert HTTP_TIMEOUT <= 30.0  # Reasonable timeout range
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.httpx.AsyncClient")
-    async def test_fetch_text_uses_http_timeout(self, mock_client_class):
-        """Test that fetch_text uses HTTP_TIMEOUT."""
-        mock_response = MagicMock()
-        mock_response.text = "Content"
-        mock_client = AsyncMock()
-        mock_client.get.return_value = mock_response
-        mock_client_class.return_value.__aenter__.return_value = mock_client
-
-        await fetch_text("https://example.com")
-
-        # Verify httpx.AsyncClient was called with timeout parameter
-        mock_client_class.assert_called_once()
-        call_kwargs = mock_client_class.call_args[1]
-        assert "timeout" in call_kwargs
-        assert call_kwargs["timeout"] == HTTP_TIMEOUT
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.httpx.AsyncClient")
-    async def test_fetch_text_json_uses_http_timeout(self, mock_client_class):
-        """Test that fetch_text_json uses HTTP_TIMEOUT."""
-        mock_response = MagicMock()
-        mock_response.json.return_value = []
-        mock_client = AsyncMock()
-        mock_client.get.return_value = mock_response
-        mock_client_class.return_value.__aenter__.return_value = mock_client
-
-        await fetch_text_json("https://example.com/api")
-
-        # Verify httpx.AsyncClient was called with timeout parameter
-        mock_client_class.assert_called_once()
-        call_kwargs = mock_client_class.call_args[1]
-        assert "timeout" in call_kwargs
-        assert call_kwargs["timeout"] == HTTP_TIMEOUT
-
-
-class TestDocFetcherConstants:
-    """Test data_fetcher constants."""
-
-    def test_qiskit_modules_not_empty(self):
-        """Test that AVAILABLE_MODULES is not empty."""
-        assert len(AVAILABLE_MODULES) > 0
-
-    def test_qiskit_modules_has_circuit(self):
-        """Test that AVAILABLE_MODULES contains circuit."""
-        assert "circuit" in AVAILABLE_MODULES
-
-    def test_qiskit_modules_has_primitives(self):
-        """Test that AVAILABLE_MODULES contains primitives."""
-        assert "primitives" in AVAILABLE_MODULES
-
-    def test_qiskit_modules_has_transpiler(self):
-        """Test that AVAILABLE_MODULES contains transpiler."""
-        assert "transpiler" in AVAILABLE_MODULES
-
-    def test_qiskit_addon_modules_not_empty(self):
-        """Test that AVAILABLE_ADDONS is not empty."""
-        assert len(AVAILABLE_ADDONS) > 0
-
-    def test_qiskit_addon_modules_has_sqd(self):
-        """Test that AVAILABLE_ADDONS contains SQD."""
-        assert "sqd" in AVAILABLE_ADDONS
-
-    def test_qiskit_addon_modules_has_cutting(self):
-        """Test that AVAILABLE_ADDONS contains cutting."""
-        assert "cutting" in AVAILABLE_ADDONS
-
-    def test_qiskit_modules_entries_are_strings(self):
-        """Test that AVAILABLE_MODULES entries are strings."""
-        for value in AVAILABLE_MODULES:
-            assert isinstance(value, str)
-
-    def test_qiskit_addon_modules_entries_are_strings(self):
-        """Test that AVAILABLE_ADDONS entries are strings."""
-        for value in AVAILABLE_ADDONS:
-            assert isinstance(value, str)
-
-
-class TestLookupErrorCode:
-    """Test lookup_error_code function."""
-
-    async def test_invalid_code_format_letters(self):
-        """Test that non-numeric codes return an error."""
-        result = await lookup_error_code("abcd")
-        assert result["status"] == "error"
-        assert "Invalid error code format" in result["message"]
-
-    async def test_invalid_code_format_short(self):
-        """Test that codes with wrong length return an error."""
-        result = await lookup_error_code("12")
-        assert result["status"] == "error"
-        assert "Invalid error code format" in result["message"]
-
-    async def test_invalid_code_format_long(self):
-        """Test that 5-digit codes return an error."""
-        result = await lookup_error_code("12345")
-        assert result["status"] == "error"
-        assert "Invalid error code format" in result["message"]
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_fetch_failure(self, mock_fetch):
-        """Test lookup when fetch fails."""
-        mock_fetch.return_value = None
-        result = await lookup_error_code("1002")
-        assert result["status"] == "error"
-        assert "Failed to fetch" in result["message"]
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_code_found(self, mock_fetch):
-        """Test successful error code lookup."""
-        mock_fetch.return_value = (
-            "<table><tr><td>1002</td>"
-            "<td>Error in the validation process.</td>"
-            "<td>Check the job.</td></tr></table>"
-        )
-        result = await lookup_error_code("1002")
-        assert result["status"] == "success"
-        assert result["code"] == "1002"
-        assert "details" in result
-        assert "1002" in result["details"]
-        assert "metadata" in result
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_code_not_found(self, mock_fetch):
-        """Test lookup for a code that does not exist in the page."""
-        mock_fetch.return_value = "<table><tr><td>1002</td><td>Some error</td></tr></table>"
-        result = await lookup_error_code("9999")
-        assert result["status"] == "error"
-        assert "not found" in result["message"]
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_metadata_url_includes_range(self, mock_fetch):
-        """Test that metadata URL points to the correct error range anchor."""
-        mock_fetch.return_value = "<table><tr><td>7001</td><td>Error</td><td>Fix</td></tr></table>"
-        result = await lookup_error_code("7001")
-        assert result["status"] == "success"
-        assert "7xxx" in result["metadata"]["url"]
-
-
-class TestGetAddonDocs:
-    """Test get_addon_docs function."""
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_addon_docs_valid(self, mock_fetch):
-        """Test getting docs for a valid addon."""
-        mock_fetch.return_value = "SQD documentation"
-        result = await get_addon_docs("sqd")
-        assert result["status"] == "success"
-        assert result["addon"] == "sqd"
-        assert "metadata" in result
-        assert "qiskit-addon-sqd" in result["metadata"]["url"]
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_addon_docs_invalid(self, mock_fetch):
-        """Test getting docs for an invalid addon."""
-        result = await get_addon_docs("nonexistent")
-        assert result["status"] == "error"
-        assert "not found" in result["message"]
-        assert "available_addons" in result
-        mock_fetch.assert_not_called()
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_addon_docs_with_suggestions(self, mock_fetch):
-        """Test getting docs with fuzzy match suggestions."""
-        result = await get_addon_docs("cut")
-        assert result["status"] == "error"
-        if "suggestions" in result:
-            assert "cutting" in result["suggestions"]
-        mock_fetch.assert_not_called()
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_addon_docs_fetch_fails(self, mock_fetch):
-        """Test get_addon_docs when fetch fails."""
-        mock_fetch.return_value = None
-        result = await get_addon_docs("cutting")
-        assert result["status"] == "error"
-
-    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
-    async def test_get_addon_docs_all_valid(self, mock_fetch):
-        """Test getting docs for all valid addons."""
-        mock_fetch.return_value = "Addon docs"
-        for addon in AVAILABLE_ADDONS:
-            result = await get_addon_docs(addon)
-            assert result["status"] == "success"
-            assert result["addon"] == addon
-
-
-class TestConvertHtmlToMarkdown:
-    """Test convert_html_to_markdown function."""
-
-    def test_basic_html(self):
-        """Test conversion of basic HTML tags."""
-        html = "<h1>Title</h1><p>Paragraph text.</p>"
-        result = convert_html_to_markdown(html)
-        assert "Title" in result
-        assert "Paragraph text." in result
-
-    def test_links_preserved(self):
-        """Test that links are preserved in markdown output."""
-        html = '<a href="https://example.com">Click here</a>'
-        result = convert_html_to_markdown(html)
-        assert "https://example.com" in result
-        assert "Click here" in result
-
-    def test_empty_html(self):
-        """Test conversion of empty HTML."""
-        result = convert_html_to_markdown("")
-        assert result.strip() == ""
-
-    def test_nested_html(self):
-        """Test conversion of nested HTML structures."""
-        html = "<div><ul><li>Item 1</li><li>Item 2</li></ul></div>"
-        result = convert_html_to_markdown(html)
-        assert "Item 1" in result
-        assert "Item 2" in result
-
-    def test_code_blocks(self):
-        """Test conversion of code blocks."""
-        html = "<pre><code>print('hello')</code></pre>"
-        result = convert_html_to_markdown(html)
-        assert "print('hello')" in result
-
-    def test_table_html(self):
-        """Test conversion of HTML tables."""
-        html = "<table><tr><td>1002</td><td>Error message</td></tr></table>"
-        result = convert_html_to_markdown(html)
-        assert "1002" in result
-        assert "Error message" in result
-
-
-class TestListHelpers:
-    """Test list helper functions."""
-
-    def test_get_list_of_modules(self):
-        """Test get_list_of_modules returns correct structure."""
-        result = get_list_of_modules()
-        assert result["status"] == "success"
-        assert "modules" in result
-        assert isinstance(result["modules"], list)
-        assert len(result["modules"]) > 0
-        assert "circuit" in result["modules"]
-
-    def test_get_list_of_addons(self):
-        """Test get_list_of_addons returns correct structure."""
-        result = get_list_of_addons()
-        assert result["status"] == "success"
-        assert "addons" in result
-        assert isinstance(result["addons"], list)
-        assert len(result["addons"]) > 0
-        assert "sqd" in result["addons"]
-
-    def test_get_list_of_guides(self):
-        """Test get_list_of_guides returns correct structure."""
-        result = get_list_of_guides()
-        assert result["status"] == "success"
-        assert "guides" in result
-        assert isinstance(result["guides"], list)
-        assert len(result["guides"]) > 0
-        assert "quick-start" in result["guides"]
-
-    def test_get_list_of_error_code_categories(self):
-        """Test get_list_of_error_code_categories returns correct structure."""
-        result = get_list_of_error_code_categories()
-        assert result["status"] == "success"
-        assert "categories" in result
-        assert isinstance(result["categories"], dict)
-        assert "registry_url" in result
-        assert "errors" in result["registry_url"]
+        assert HTTP_TIMEOUT <= 30.0

--- a/qiskit-docs-mcp-server/tests/test_server.py
+++ b/qiskit-docs-mcp-server/tests/test_server.py
@@ -26,10 +26,8 @@ class TestServerRegistration:
         """Test that all expected tools are registered."""
         tool_names = {tool.name for tool in mcp._tool_manager._tools.values()}
         expected_tools = {
-            "get_sdk_module_docs_tool",
-            "get_addon_docs_tool",
-            "get_guide_tool",
             "search_docs_tool",
+            "get_page_tool",
             "lookup_error_code_tool",
         }
         assert expected_tools.issubset(tool_names), f"Missing tools: {expected_tools - tool_names}"
@@ -49,7 +47,19 @@ class TestServerRegistration:
 
     def test_tool_count(self):
         """Test the expected number of tools."""
-        assert len(mcp._tool_manager._tools) == 5
+        assert len(mcp._tool_manager._tools) == 3
+
+    def test_old_tools_removed(self):
+        """Test that old category-specific tools are no longer registered."""
+        tool_names = {tool.name for tool in mcp._tool_manager._tools.values()}
+        removed_tools = {
+            "get_sdk_module_docs_tool",
+            "get_addon_docs_tool",
+            "get_guide_tool",
+        }
+        assert removed_tools.isdisjoint(tool_names), (
+            f"Old tools still registered: {removed_tools & tool_names}"
+        )
 
     def test_resource_count(self):
         """Test the expected number of resources."""


### PR DESCRIPTION
## Summary

Closes #153

Depends on #160

Improves tool and resource descriptions across the qiskit-docs-mcp-server to help LLMs make better tool selection decisions. Aligned with the 3-tool search-first architecture from #160.

- **`search_docs_tool`**: Detailed docstring with scope values and usage guidance
- **`get_page_tool`**: Comprehensive description covering all supported URL patterns (SDK modules, classes, addons, guides)
- **`lookup_error_code_tool`**: Error code ranges documented inline for quick reference
- **Resources**: Each resource now describes how to use its output with `get_page_tool` or `search_docs_tool`
- **Constants**: `AVAILABLE_MODULES`/`ADDONS`/`GUIDES` as `dict[str, str]` with descriptions, resource helpers return `{name, description, url_path}`