### PR TITLE
docs(docs-server): fix README to match 3-tool architecture

### DIFF
--- a/qiskit-docs-mcp-server/README.md
+++ b/qiskit-docs-mcp-server/README.md
@@ -23,14 +23,12 @@ The Qiskit Documentation MCP Server provides AI assistants and agents with seaml
 
 ### Tools
 
-The server implements five tools for documentation access:
+The server implements three tools for documentation access:
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| `get_sdk_module_docs_tool` | Get documentation for Qiskit SDK modules | `module`: Module name (e.g., circuit, transpiler, quantum_info, primitives, synthesis, dagcircuit — see `qiskit-docs://modules` resource for full list) |
-| `get_addon_docs_tool` | Get documentation for Qiskit addon packages | `addon`: Addon name (e.g., sqd, cutting, mpf, obp, aqc-tensor) |
-| `get_guide_tool` | Get Qiskit implementation guides and best practices | `guide`: Guide name (e.g., quick-start, construct-circuits, transpile, configure-error-mitigation, dynamic-circuits — see `qiskit-docs://guides` resource for full list) |
-| `search_docs_tool` | Search Qiskit documentation for relevant content | `query`: Search query string<br>`module`: Search scope (default: "documentation") |
+| `search_docs_tool` | Search across the entire Qiskit documentation for relevant content | `query`: Search query string<br>`scope`: Search scope filter — `all` (default), `documentation`, `api`, `learning`, `tutorials` |
+| `get_page_tool` | Fetch any Qiskit documentation page and return as markdown | `url`: Full URL or relative path (e.g., `guides/transpile`, `api/qiskit/circuit`)<br>`max_length`: Max characters to return (default: 20000, 0 for unlimited)<br>`offset`: Character offset for pagination (default: 0) |
 | `lookup_error_code_tool` | Look up a Qiskit/IBM Quantum error code | `code`: 4-digit error code (e.g., 1002, 7001, 8004) |
 
 ### Resources
@@ -193,22 +191,6 @@ asyncio.run(main())
 
 ## Usage Examples
 
-### Get SDK Module Documentation
-
-```python
-# Query circuit module documentation
-result = await get_sdk_module_docs_tool("circuit")
-print(result["documentation"])
-```
-
-### Get Implementation Guide
-
-```python
-# Get error mitigation guide
-result = await get_guide_tool("configure-error-mitigation")
-print(result["documentation"])
-```
-
 ### Search Documentation
 
 ```python
@@ -216,7 +198,28 @@ print(result["documentation"])
 result = await search_docs_tool("transpiler optimization")
 print(f"Found {result['total_results']} results")
 for item in result["results"]:
-    print(f"- {item['name']}: {item['url']}")
+    print(f"- {item['title']}: {item['url']}")
+```
+
+### Fetch a Documentation Page
+
+```python
+# Fetch circuit module API reference
+result = await get_page_tool("api/qiskit/circuit")
+print(result["documentation"])
+
+# Fetch with pagination for large pages
+result = await get_page_tool("api/qiskit/circuit", max_length=5000)
+if result["has_more"]:
+    next_page = await get_page_tool("api/qiskit/circuit", offset=result["next_offset"])
+```
+
+### Look Up an Error Code
+
+```python
+# Look up error code 1002
+result = await lookup_error_code_tool("1002")
+print(result["details"])
 ```
 
 ## Available Documentation
@@ -262,14 +265,17 @@ for item in result["results"]:
 
 ## Features
 
-### Fuzzy Matching
+### Pagination Support
 
-The server includes intelligent fuzzy matching for module and guide names:
+Large documentation pages are automatically paginated. Use `max_length` and `offset` to control content retrieval:
 
 ```python
-# Typo in module name - server suggests correct spelling
-result = await get_sdk_module_docs_tool("circuitt")
-# Returns: {"status": "error", "suggestions": ["circuit"]}
+# Fetch first 5000 characters
+result = await get_page_tool("api/qiskit/circuit", max_length=5000)
+# result["has_more"] == True, result["next_offset"] == 5000
+
+# Fetch unlimited content
+result = await get_page_tool("api/qiskit/circuit", max_length=0)
 ```
 
 ### Metadata Inclusion
@@ -279,8 +285,10 @@ All responses include rich metadata:
 ```python
 {
     "status": "success",
-    "module": "circuit",
+    "url": "https://quantum.cloud.ibm.com/docs/api/qiskit/circuit",
     "documentation": "...",
+    "has_more": False,
+    "total_length": 15420,
     "metadata": {
         "url": "https://quantum.cloud.ibm.com/docs/api/qiskit/circuit",
         "timestamp": "2026-03-03T03:00:00Z",
@@ -345,10 +353,10 @@ See the [`examples/`](examples/) directory for complete working examples:
 export QISKIT_HTTP_TIMEOUT=30.0
 ```
 
-### Module Not Found
+### Page Not Found
 
-**Problem**: "Module 'xyz' not found"
-**Solution**: Check available modules using the `qiskit-docs://modules` resource or see the Available Documentation section above
+**Problem**: "Failed to fetch" error from `get_page_tool`
+**Solution**: Use `search_docs_tool` to find the correct URL, or check the `qiskit-docs://modules` and `qiskit-docs://guides` resources for valid paths
 
 ## Contributing
 

--- a/qiskit-docs-mcp-server/README.md
+++ b/qiskit-docs-mcp-server/README.md
@@ -12,7 +12,7 @@ The Qiskit Documentation MCP Server provides AI assistants and agents with seaml
 
 ### Key Features
 
-- **📚 Complete Documentation Access**: Query all Qiskit SDK modules (circuit, primitives, transpiler, quantum_info, result, visualization)
+- **📚 Complete Documentation Access**: Query all 16 Qiskit SDK modules, 6 addon packages, and 30+ implementation guides
 - **📖 Implementation Guides**: Access best practices for optimization, error mitigation, dynamic circuits, and more
 - **🔍 Smart Search**: Search across the entire Qiskit documentation with fuzzy matching
 - **🎯 No Authentication Required**: Public documentation access without API tokens
@@ -27,9 +27,9 @@ The server implements five tools for documentation access:
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| `get_sdk_module_docs_tool` | Get documentation for Qiskit SDK modules | `module`: Module name (circuit, primitives, transpiler, quantum_info, result, visualization) |
+| `get_sdk_module_docs_tool` | Get documentation for Qiskit SDK modules | `module`: Module name (e.g., circuit, transpiler, quantum_info, primitives, synthesis, dagcircuit — see `qiskit-docs://modules` resource for full list) |
 | `get_addon_docs_tool` | Get documentation for Qiskit addon packages | `addon`: Addon name (e.g., sqd, cutting, mpf, obp, aqc-tensor) |
-| `get_guide_tool` | Get Qiskit implementation guides and best practices | `guide`: Guide name (optimization, quantum-circuits, error-mitigation, dynamic-circuits, parametric-compilation, performance-tuning) |
+| `get_guide_tool` | Get Qiskit implementation guides and best practices | `guide`: Guide name (e.g., quick-start, construct-circuits, transpile, configure-error-mitigation, dynamic-circuits — see `qiskit-docs://guides` resource for full list) |
 | `search_docs_tool` | Search Qiskit documentation for relevant content | `query`: Search query string<br>`module`: Search scope (default: "documentation") |
 | `lookup_error_code_tool` | Look up a Qiskit/IBM Quantum error code | `code`: 4-digit error code (e.g., 1002, 7001, 8004) |
 
@@ -155,43 +155,37 @@ Add to your Cline MCP settings:
 
 > **Note:** To run LangChain examples you will need to install the dependencies:
 > ```bash
-> pip install langchain langchain-mcp-adapters langchain-openai python-dotenv
+> pip install langchain-mcp-adapters langchain-openai langgraph
 > ```
 
 ```python
 import asyncio
-from langchain.agents import create_agent
+
 from langchain_mcp_adapters.client import MultiServerMCPClient
-from langchain_mcp_adapters.tools import load_mcp_tools
 from langchain_openai import ChatOpenAI
+from langgraph.prebuilt import create_react_agent
 
 async def main():
     # Configure MCP client
-    mcp_client = MultiServerMCPClient({
-        "qiskit-docs": {
-            "transport": "stdio",
-            "command": "qiskit-docs-mcp-server",
-            "args": [],
+    async with MultiServerMCPClient(
+        {
+            "qiskit-docs": {
+                "command": "qiskit-docs-mcp-server",
+                "args": [],
+                "transport": "stdio",
+            }
         }
-    })
-
-    # Use persistent session for efficient tool calls
-    async with mcp_client.session("qiskit-docs") as session:
-        # Load MCP tools
-        tools = await load_mcp_tools(session)
-
-        # Create agent with LLM
-        llm = ChatOpenAI(model="gpt-4o", temperature=0)
-        agent = create_agent(
-            llm,
-            tools,
-            system_prompt="You are a helpful quantum computing documentation assistant."
+    ) as client:
+        # Create agent with LLM and MCP tools
+        agent = create_react_agent(
+            ChatOpenAI(model="gpt-4o"),
+            client.get_tools(),
         )
 
         # Query documentation
-        response = await agent.ainvoke({
-            "messages": [("user", "How do I create a quantum circuit in Qiskit?")]
-        })
+        response = await agent.ainvoke(
+            {"messages": [("user", "How do I create a quantum circuit in Qiskit?")]}
+        )
         print(response["messages"][-1].content)
 
 asyncio.run(main())
@@ -211,7 +205,7 @@ print(result["documentation"])
 
 ```python
 # Get error mitigation guide
-result = await get_guide_tool("error-mitigation")
+result = await get_guide_tool("configure-error-mitigation")
 print(result["documentation"])
 ```
 
@@ -232,22 +226,39 @@ for item in result["results"]:
 | Module | Description |
 |--------|-------------|
 | `circuit` | Quantum circuit construction and manipulation |
-| `primitives` | Sampler and Estimator primitives for quantum execution |
-| `transpiler` | Circuit transpilation and optimization |
 | `quantum_info` | Quantum information theory utilities |
+| `transpiler` | Circuit transpilation and optimization |
+| `synthesis` | Circuit synthesis algorithms |
+| `dagcircuit` | DAG representation of quantum circuits |
+| `passmanager` | Transpiler pass manager framework |
+| `converters` | Circuit format converters |
+| `compiler` | High-level compilation routines |
+| `primitives` | Sampler and Estimator primitives |
+| `providers` | Backend providers and job management |
 | `result` | Job result handling and analysis |
-| `visualization` | Circuit and result visualization tools |
+| `visualization` | Circuit and result visualization |
+| `qasm2` | OpenQASM 2.0 support |
+| `qasm3` | OpenQASM 3.0 support |
+| `qpy` | Qiskit Python serialization format |
+| `utils` | General utility functions |
+| `exceptions` | Qiskit exception classes |
 
 ### Implementation Guides
 
 | Guide | Description |
 |-------|-------------|
-| `optimization` | Quantum optimization techniques and algorithms |
-| `quantum-circuits` | Circuit design patterns and best practices |
-| `error-mitigation` | Error mitigation strategies for noisy quantum devices |
+| `quick-start` | Get started with Qiskit |
+| `construct-circuits` | Build and manipulate quantum circuits |
+| `transpile` | Transpile circuits for target backends |
+| `transpiler-stages` | Understand transpiler pipeline stages |
+| `configure-error-mitigation` | Configure error mitigation for primitives |
+| `configure-error-suppression` | Configure error suppression techniques |
+| `primitives` | Use Sampler and Estimator primitives |
+| `execution-modes` | Job, session, and batch execution modes |
 | `dynamic-circuits` | Mid-circuit measurements and classical control |
-| `parametric-compilation` | Parameterized circuit compilation techniques |
-| `performance-tuning` | Performance optimization tips and tricks |
+| `functions` | Overview of Qiskit Functions |
+
+> See the `qiskit-docs://guides` resource for the complete list of 30+ available guides.
 
 ## Features
 


### PR DESCRIPTION
## Summary

Closes #156

Depends on #160

Updates the qiskit-docs-mcp-server README to accurately reflect the 3-tool search-first architecture from #160.

- **Tools table**: Updated from 5 tools to 3 (`search_docs_tool`, `get_page_tool`, `lookup_error_code_tool`) with correct parameters
- **Usage examples**: Replaced old `get_sdk_module_docs_tool`/`get_guide_tool` examples with `search_docs_tool`, `get_page_tool` (with pagination), and `lookup_error_code_tool`
- **Features section**: Replaced "Fuzzy Matching" with "Pagination Support" documentation
- **Metadata example**: Updated response shape to match `get_page_docs` output format
- **Troubleshooting**: "Module Not Found" → "Page Not Found" with guidance to use `search_docs_tool`