### PR TITLE
feat(docs-server): strip navigation chrome before markdown conversion

### DIFF
--- a/qiskit-docs-mcp-server/pyproject.toml
+++ b/qiskit-docs-mcp-server/pyproject.toml
@@ -5,6 +5,7 @@ description = "MCP server for Qiskit documentation retrieval and search"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"
 dependencies = [
+    "beautifulsoup4>=4.12.0",
     "fastmcp>=2.8.1,<3",
     "html2text>=2020.1.16",
     "httpx>=0.28.1",

--- a/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/data_fetcher.py
+++ b/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/data_fetcher.py
@@ -18,6 +18,7 @@ from urllib.parse import quote, urlparse
 
 import html2text
 import httpx
+from bs4 import BeautifulSoup
 
 from qiskit_docs_mcp_server.constants import (
     AVAILABLE_ADDONS,
@@ -49,8 +50,62 @@ def _strip_html_tags(text: str) -> str:
     return re.sub(r"<[^>]+>", "", text)
 
 
+def extract_main_content(html: str) -> str:
+    """Extract main content from HTML, removing navigation chrome.
+
+    Strips nav, header, footer, aside elements and ARIA-role navigation,
+    then returns the <main>, <article>, or role='main' content. Falls back
+    to <body> (with chrome removed) if no semantic main content is found.
+
+    Args:
+        html: Full HTML page content
+
+    Returns:
+        HTML string with only the main content
+    """
+    soup = BeautifulSoup(html, "html.parser")
+
+    # Remove structural chrome elements
+    for tag_name in ["nav", "header", "footer", "aside"]:
+        for element in soup.find_all(tag_name):
+            element.decompose()
+
+    # Remove ARIA-role navigation elements
+    for role in ["navigation", "banner", "contentinfo", "complementary"]:
+        for element in soup.find_all(attrs={"role": role}):
+            element.decompose()
+
+    # Remove skip-to-content links
+    for element in soup.find_all("a", class_=lambda c: c and "skip" in c.lower()):
+        element.decompose()
+    for element in soup.find_all("a", string=lambda s: s and "skip to" in s.lower()):
+        element.decompose()
+
+    # Return the best semantic container
+    main_content = soup.find("main")
+    if main_content:
+        return str(main_content)
+
+    article = soup.find("article")
+    if article:
+        return str(article)
+
+    main_role = soup.find(attrs={"role": "main"})
+    if main_role:
+        return str(main_role)
+
+    body = soup.find("body")
+    if body:
+        return str(body)
+
+    return str(soup)
+
+
 def convert_html_to_markdown(html: str) -> str:
     """Convert HTML content to Markdown format.
+
+    Strips navigation chrome (header, footer, nav, aside) before conversion
+    to produce cleaner markdown output.
 
     Args:
         html: HTML content string
@@ -58,11 +113,12 @@ def convert_html_to_markdown(html: str) -> str:
     Returns:
         Markdown formatted content
     """
+    content_html = extract_main_content(html)
     h = html2text.HTML2Text()
     h.ignore_links = False
     h.body_width = 0
     h.ignore_images = False
-    return h.handle(html)
+    return h.handle(content_html)
 
 
 def _truncate_content(content: str, max_length: int = 20000, offset: int = 0) -> dict[str, Any]:

--- a/qiskit-docs-mcp-server/tests/test_data_fetcher.py
+++ b/qiskit-docs-mcp-server/tests/test_data_fetcher.py
@@ -28,6 +28,7 @@ from qiskit_docs_mcp_server.data_fetcher import (
     _strip_html_tags,
     _truncate_content,
     convert_html_to_markdown,
+    extract_main_content,
     fetch_text,
     fetch_text_json,
     get_list_of_addons,
@@ -475,6 +476,114 @@ class TestLookupErrorCode:
         result = await lookup_error_code("9999")
         assert result["status"] == "error"
         assert "not found" in result["message"]
+
+
+class TestExtractMainContent:
+    """Test main content extraction from HTML."""
+
+    def test_extracts_main_tag(self):
+        """Test extraction of main tag content."""
+        html = "<html><body><nav>Nav</nav><main><h1>Title</h1><p>Content</p></main><footer>Footer</footer></body></html>"
+        result = extract_main_content(html)
+        assert "Title" in result
+        assert "Content" in result
+        assert "Nav" not in result
+        assert "Footer" not in result
+
+    def test_extracts_article_fallback(self):
+        """Test fallback to article tag."""
+        html = "<html><body><nav>Nav</nav><article><h1>Title</h1></article></body></html>"
+        result = extract_main_content(html)
+        assert "Title" in result
+        assert "Nav" not in result
+
+    def test_extracts_role_main_fallback(self):
+        """Test fallback to role=main."""
+        html = '<html><body><nav>Nav</nav><div role="main"><p>Content</p></div></body></html>'
+        result = extract_main_content(html)
+        assert "Content" in result
+        assert "Nav" not in result
+
+    def test_removes_nav_elements(self):
+        """Test that nav elements are removed."""
+        html = "<html><body><nav>Navigation</nav><main><p>Content</p></main></body></html>"
+        result = extract_main_content(html)
+        assert "Navigation" not in result
+
+    def test_removes_header_elements(self):
+        """Test that header elements are removed."""
+        html = "<html><body><header>Header</header><main><p>Content</p></main></body></html>"
+        result = extract_main_content(html)
+        assert "Header" not in result
+
+    def test_removes_footer_elements(self):
+        """Test that footer elements are removed."""
+        html = "<html><body><main><p>Content</p></main><footer>Footer</footer></body></html>"
+        result = extract_main_content(html)
+        assert "Footer" not in result
+
+    def test_removes_aside_elements(self):
+        """Test that aside elements are removed."""
+        html = "<html><body><aside>Sidebar</aside><main><p>Content</p></main></body></html>"
+        result = extract_main_content(html)
+        assert "Sidebar" not in result
+
+    def test_removes_navigation_role(self):
+        """Test that elements with role=navigation are removed."""
+        html = (
+            '<html><body><div role="navigation">Nav</div><main><p>Content</p></main></body></html>'
+        )
+        result = extract_main_content(html)
+        assert "Nav" not in result
+
+    def test_removes_skip_links(self):
+        """Test that skip-to-content links are removed."""
+        html = '<html><body><a class="skip-link">Skip to main content</a><main><p>Content</p></main></body></html>'
+        result = extract_main_content(html)
+        assert "Skip to main content" not in result
+
+    def test_body_fallback(self):
+        """Test fallback to body when no main/article found."""
+        html = "<html><body><nav>Nav</nav><div><p>Content</p></div></body></html>"
+        result = extract_main_content(html)
+        assert "Content" in result
+        assert "Nav" not in result
+
+    def test_empty_html(self):
+        """Test with empty HTML."""
+        result = extract_main_content("")
+        assert result is not None
+
+    def test_plain_content(self):
+        """Test with simple content without structure."""
+        html = "<p>Just a paragraph</p>"
+        result = extract_main_content(html)
+        assert "Just a paragraph" in result
+
+
+class TestConvertHtmlToMarkdownWithExtraction:
+    """Test that convert_html_to_markdown strips chrome before converting."""
+
+    def test_chrome_not_in_markdown(self):
+        """Test that navigation chrome is not in final markdown output."""
+        html = """
+        <html>
+        <body>
+            <nav><ul><li><a href="/">Home</a></li><li><a href="/docs">Docs</a></li></ul></nav>
+            <header><h1>IBM Quantum Platform</h1></header>
+            <main>
+                <h1>Circuit Module</h1>
+                <p>The circuit module provides QuantumCircuit class.</p>
+            </main>
+            <footer><p>Copyright IBM 2026</p></footer>
+        </body>
+        </html>
+        """
+        result = convert_html_to_markdown(html)
+        assert "Circuit Module" in result
+        assert "QuantumCircuit" in result
+        assert "IBM Quantum Platform" not in result
+        assert "Copyright IBM" not in result
 
 
 class TestConvertHtmlToMarkdown:

--- a/uv.lock
+++ b/uv.lock
@@ -4644,6 +4644,7 @@ name = "qiskit-docs-mcp-server"
 version = "0.1.1"
 source = { editable = "qiskit-docs-mcp-server" }
 dependencies = [
+    { name = "beautifulsoup4" },
     { name = "fastmcp" },
     { name = "html2text" },
     { name = "httpx" },
@@ -4676,6 +4677,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "fastmcp", specifier = ">=2.8.1,<3" },
     { name = "html2text", specifier = ">=2020.1.16" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
## Summary
- Adds `extract_main_content()` using BeautifulSoup to remove nav, header, footer, aside, and ARIA-role navigation elements
- Updates `convert_html_to_markdown()` to strip chrome before conversion, producing cleaner documentation output
- Adds `beautifulsoup4>=4.12.0` dependency

Stacked on #160.

Closes #150