### PR TITLE
fix: replace retired ibm_torino backend with ibm_boston

### DIFF
--- a/qiskit-gym-mcp-server/src/qiskit_gym_mcp_server/coupling_maps.py
+++ b/qiskit-gym-mcp-server/src/qiskit_gym_mcp_server/coupling_maps.py
@@ -787,7 +787,7 @@ async def get_fake_backend_coupling_map(backend_name: str) -> dict[str, Any]:
     for offline development and testing.
 
     Args:
-        backend_name: Backend name (e.g., "ibm_fez", "ibm_brisbane", "ibm_torino")
+        backend_name: Backend name (e.g., "ibm_fez", "ibm_brisbane", "ibm_boston")
 
     Returns:
         Dict with exact coupling map edges, num_qubits, and backend info

--- a/qiskit-gym-mcp-server/src/qiskit_gym_mcp_server/server_tools.py
+++ b/qiskit-gym-mcp-server/src/qiskit_gym_mcp_server/server_tools.py
@@ -872,7 +872,7 @@ async def get_fake_backend_coupling_map_tool(backend_name: str) -> dict[str, Any
     topologies for offline development.
 
     Args:
-        backend_name: Backend name (e.g., "ibm_fez", "ibm_brisbane", "ibm_torino",
+        backend_name: Backend name (e.g., "ibm_fez", "ibm_brisbane", "ibm_boston",
             "ibm_sherbrooke"). Use list_available_fake_backends to see all options.
 
     Returns:

--- a/qiskit-ibm-transpiler-mcp-server/README.md
+++ b/qiskit-ibm-transpiler-mcp-server/README.md
@@ -246,7 +246,7 @@ hybrid_ai_transpile(
 ```
 **Parameters:**
 - `circuit`: quantum circuit as QASM 3.0 string or base64-encoded QPY
-- `backend_name`: Target IBM Quantum backend (e.g., 'ibm_torino', 'ibm_fez')
+- `backend_name`: Target IBM Quantum backend (e.g., 'ibm_boston', 'ibm_fez')
 - `ai_optimization_level` (optional): Optimization level (1-3) for AI components. Higher values yield better results but require more computational resources
 - `optimization_level` (optional): Optimization level (1-3) for heuristic components in the PassManager
 - `ai_layout_mode` (optional): Specifies how the AI routing component handles layout selection:

--- a/qiskit-ibm-transpiler-mcp-server/src/qiskit_ibm_transpiler_mcp_server/qta.py
+++ b/qiskit-ibm-transpiler-mcp-server/src/qiskit_ibm_transpiler_mcp_server/qta.py
@@ -413,7 +413,7 @@ async def hybrid_ai_transpile(
 
     Args:
         circuit: quantum circuit as QASM 3.0 string or base64-encoded QPY.
-        backend_name: Qiskit Runtime Service backend name (e.g., 'ibm_torino', 'ibm_fez')
+        backend_name: Qiskit Runtime Service backend name (e.g., 'ibm_boston', 'ibm_fez')
         ai_optimization_level: Optimization level (1-3) for AI components. Higher values
             yield better results but require more computational resources.
         optimization_level: Optimization level (1-3) for heuristic components in the PassManager.

--- a/qiskit-ibm-transpiler-mcp-server/src/qiskit_ibm_transpiler_mcp_server/server.py
+++ b/qiskit-ibm-transpiler-mcp-server/src/qiskit_ibm_transpiler_mcp_server/server.py
@@ -72,7 +72,7 @@ async def ai_routing_tool(
 
     Args:
         circuit: Input quantum circuit as QASM 3.0 string or base64-encoded QPY
-        backend_name: Target IBM Quantum backend (e.g., 'ibm_torino', 'ibm_fez')
+        backend_name: Target IBM Quantum backend (e.g., 'ibm_boston', 'ibm_fez')
         optimization_level: 1 (fastest, least optimization) to 3 (slowest, most optimization)
         layout_mode: 'keep' (respect existing layout), 'improve' (refine initial guess), 'optimize' (best for general circuits)
         optimization_preferences: What to minimize - 'n_cnots', 'n_gates', 'cnot_layers', 'layers', or 'noise'. Can be a list.
@@ -114,7 +114,7 @@ async def ai_linear_function_synthesis_tool(
 
     Args:
         circuit: Input quantum circuit as QASM 3.0 string or base64-encoded QPY
-        backend_name: Target IBM Quantum backend (e.g., 'ibm_torino', 'ibm_fez')
+        backend_name: Target IBM Quantum backend (e.g., 'ibm_boston', 'ibm_fez')
         replace_only_if_better: If True, only replaces sub-circuits when synthesis improves CNOT count
         local_mode: True runs locally (recommended), False uses remote Qiskit Transpiler Service
         circuit_format: Format of the input circuit - 'qasm3' (default) or 'qpy' (base64-encoded QPY for full circuit fidelity)
@@ -148,7 +148,7 @@ async def ai_clifford_synthesis_tool(
 
     Args:
         circuit: Input quantum circuit as QASM 3.0 string or base64-encoded QPY
-        backend_name: Target IBM Quantum backend (e.g., 'ibm_torino', 'ibm_fez')
+        backend_name: Target IBM Quantum backend (e.g., 'ibm_boston', 'ibm_fez')
         replace_only_if_better: If True, only replaces sub-circuits when synthesis improves CNOT count
         local_mode: True runs locally (recommended), False uses remote Qiskit Transpiler Service
         circuit_format: Format of the input circuit - 'qasm3' (default) or 'qpy' (base64-encoded QPY for full circuit fidelity)
@@ -182,7 +182,7 @@ async def ai_permutation_synthesis_tool(
 
     Args:
         circuit: Input quantum circuit as QASM 3.0 string or base64-encoded QPY
-        backend_name: Target IBM Quantum backend (e.g., 'ibm_torino', 'ibm_fez')
+        backend_name: Target IBM Quantum backend (e.g., 'ibm_boston', 'ibm_fez')
         replace_only_if_better: If True, only replaces sub-circuits when synthesis improves CNOT count
         local_mode: True runs locally (recommended), False uses remote Qiskit Transpiler Service
         circuit_format: Format of the input circuit - 'qasm3' (default) or 'qpy' (base64-encoded QPY for full circuit fidelity)
@@ -216,7 +216,7 @@ async def ai_pauli_network_synthesis_tool(
 
     Args:
         circuit: Input quantum circuit as QASM 3.0 string or base64-encoded QPY
-        backend_name: Target IBM Quantum backend (e.g., 'ibm_torino', 'ibm_fez')
+        backend_name: Target IBM Quantum backend (e.g., 'ibm_boston', 'ibm_fez')
         replace_only_if_better: If True, only replaces sub-circuits when synthesis improves CNOT count
         local_mode: True runs locally (recommended), False uses remote Qiskit Transpiler Service
         circuit_format: Format of the input circuit - 'qasm3' (default) or 'qpy' (base64-encoded QPY for full circuit fidelity)
@@ -256,7 +256,7 @@ async def hybrid_ai_transpile_tool(
 
     Args:
         circuit: Input quantum circuit as QASM 3.0 string or base64-encoded QPY
-        backend_name: Target IBM Quantum backend (e.g., 'ibm_torino', 'ibm_fez')
+        backend_name: Target IBM Quantum backend (e.g., 'ibm_boston', 'ibm_fez')
         ai_optimization_level: Optimization level (1-3) for AI components. Higher = better results but slower.
         optimization_level: Optimization level (1-3) for heuristic components.
         ai_layout_mode: Layout selection strategy:

--- a/qiskit-ibm-transpiler-mcp-server/tests/conftest.py
+++ b/qiskit-ibm-transpiler-mcp-server/tests/conftest.py
@@ -69,7 +69,7 @@ def mock_ai_synthesis_failure():
 @pytest.fixture
 def backend_name():
     """Set real backend name"""
-    return os.getenv("TEST_BACKEND_NAME", "ibm_torino")
+    return os.getenv("TEST_BACKEND_NAME", "ibm_boston")
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- `ibm_torino` has been retired from IBM Quantum Platform, causing all transpiler server integration tests to fail with `No backend matches the criteria`
- Updates the default test backend in `conftest.py` from `ibm_torino` to `ibm_boston`
- Updates all docstring examples across transpiler and gym servers to reference `ibm_boston` instead