### PR TITLE
feat(docs-server): add instructions parameter to FastMCP server

### DIFF
--- a/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/server.py
+++ b/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/server.py
@@ -38,7 +38,25 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Initialize FastMCP server
-mcp = FastMCP("Qiskit Documentation")
+mcp = FastMCP(
+    "Qiskit Documentation",
+    instructions="""\
+This server provides access to the Qiskit and IBM Quantum documentation.
+
+Recommended workflow:
+1. Use search_docs_tool to find relevant pages. Specific queries yield \
+better results than broad ones.
+2. Use get_page_tool to fetch the full content of pages found by search. \
+For large pages, use the offset parameter to paginate through content.
+3. Browse qiskit-docs:// resources (modules, addons, guides, error-codes) \
+to discover what documentation is available.
+4. Use lookup_error_code_tool with a 4-digit code when a user encounters \
+a Qiskit or IBM Quantum error.
+
+Prefer search over browsing for specific questions. Combine search to \
+find the right page, then fetch to read its content in full.\
+""",
+)
 
 logger.info("Qiskit Documentation MCP Server initialized")
 

--- a/qiskit-docs-mcp-server/tests/test_server.py
+++ b/qiskit-docs-mcp-server/tests/test_server.py
@@ -22,6 +22,17 @@ class TestServerRegistration:
         """Test the MCP server has the correct name."""
         assert mcp.name == "Qiskit Documentation"
 
+    def test_server_instructions(self):
+        """Test the MCP server has instructions set."""
+        assert mcp.instructions is not None
+        assert isinstance(mcp.instructions, str)
+        assert len(mcp.instructions) > 0
+        # Verify instructions mention key workflow concepts
+        assert "search_docs_tool" in mcp.instructions
+        assert "get_page_tool" in mcp.instructions
+        assert "lookup_error_code_tool" in mcp.instructions
+        assert "qiskit-docs://" in mcp.instructions
+
     def test_tools_registered(self):
         """Test that all expected tools are registered."""
         tool_names = {tool.name for tool in mcp._tool_manager._tools.values()}


### PR DESCRIPTION
## Summary

- Add `instructions` parameter to the `FastMCP()` constructor to guide LLMs on how to orchestrate tools and resources together
- Instructions describe the recommended workflow: search first, fetch content, browse resources, and look up error codes
- Add test verifying instructions are set and mention key workflow concepts

Closes #166