### PR TITLE
feat(docs-server): add lifespan for httpx client lifecycle management

### DIFF
--- a/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/data_fetcher.py
+++ b/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/data_fetcher.py
@@ -72,6 +72,16 @@ _json_cache = _TTLCache(ttl=CACHE_TTL)
 _client_holder: dict[str, httpx.AsyncClient] = {}
 
 
+def set_http_client(client: httpx.AsyncClient) -> None:
+    """Set the shared HTTP client (called by server lifespan)."""
+    _client_holder["client"] = client
+
+
+def clear_http_client() -> None:
+    """Clear the shared HTTP client (called on server shutdown)."""
+    _client_holder.clear()
+
+
 def _get_http_client() -> httpx.AsyncClient:
     """Get or create a shared HTTP client."""
     client = _client_holder.get("client")

--- a/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/server.py
+++ b/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/server.py
@@ -18,11 +18,16 @@ for querying and retrieving Qiskit documentation content and summaries.
 """
 
 import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import Any
 
+import httpx
 from fastmcp import FastMCP
 
+from qiskit_docs_mcp_server.constants import HTTP_TIMEOUT
 from qiskit_docs_mcp_server.data_fetcher import (
+    clear_http_client,
     get_list_of_addons,
     get_list_of_error_code_categories,
     get_list_of_guides,
@@ -30,6 +35,7 @@ from qiskit_docs_mcp_server.data_fetcher import (
     get_page_docs,
     lookup_error_code,
     search_qiskit_docs,
+    set_http_client,
 )
 
 
@@ -37,8 +43,18 @@ from qiskit_docs_mcp_server.data_fetcher import (
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
+@asynccontextmanager
+async def lifespan(server: FastMCP) -> AsyncIterator[None]:
+    """Manage the httpx client lifecycle."""
+    async with httpx.AsyncClient(timeout=HTTP_TIMEOUT, follow_redirects=True) as client:
+        set_http_client(client)
+        yield
+    clear_http_client()
+
+
 # Initialize FastMCP server
-mcp = FastMCP("Qiskit Documentation")
+mcp = FastMCP("Qiskit Documentation", lifespan=lifespan)
 
 logger.info("Qiskit Documentation MCP Server initialized")
 


### PR DESCRIPTION
## Summary

- Add an `async` lifespan context manager that creates the `httpx.AsyncClient` on server startup and properly closes it on shutdown
- Wire it into `FastMCP()` via the `lifespan` parameter
- Prevents resource leaks and `ResourceWarning` for unclosed connections
- The existing `_get_http_client()` fallback is preserved for testing and standalone usage

Closes #167
