### PR TITLE
fix(docs-server): improve lookup_error_code HTML parsing robustness

### DIFF
--- a/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/data_fetcher.py
+++ b/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/data_fetcher.py
@@ -451,7 +451,7 @@ async def lookup_error_code(code: str) -> dict[str, Any]:
         }
 
     url = f"{QISKIT_DOCS_BASE}errors"
-    logger.info(f"Fetching error code {code} from {url}")
+    logger.info("Fetching error code %s from %s", code, url)
     html = await fetch_text(url)
 
     if not html:
@@ -461,29 +461,44 @@ async def lookup_error_code(code: str) -> dict[str, Any]:
             "metadata": {"url": url},
         }
 
-    docs = convert_html_to_markdown(html)
+    soup = BeautifulSoup(html, "html.parser")
 
-    # Search for the error code in the markdown content
-    lines = docs.split("\n")
-    matching_lines: list[str] = []
-    for i, line in enumerate(lines):
-        if re.search(rf"\b{code}\b", line):
-            start = max(0, i - 2)
-            end = min(len(lines), i + 3)
-            matching_lines.extend(lines[start:end])
-            break
+    # Strategy 1: Search in table rows
+    for row in soup.find_all("tr"):
+        cells = row.find_all(["td", "th"])
+        row_text = " ".join(cell.get_text(strip=True) for cell in cells)
+        if re.search(rf"\b{code}\b", row_text):
+            details = " | ".join(cell.get_text(strip=True) for cell in cells)
+            return {
+                "status": "success",
+                "code": code,
+                "details": details,
+                "metadata": {
+                    "url": f"{url}#{code[0]}xxx",
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "content_type": "text",
+                },
+            }
 
-    if matching_lines:
-        return {
-            "status": "success",
-            "code": code,
-            "details": "\n".join(matching_lines).strip(),
-            "metadata": {
-                "url": f"{url}#{code[0]}xxx",
-                "timestamp": datetime.now(timezone.utc).isoformat(),
-                "content_type": "markdown",
-            },
-        }
+    # Strategy 2: Search in any element containing the code
+    code_pattern = re.compile(rf"\b{code}\b")
+    for element in soup.find_all(string=code_pattern):
+        # Get the parent block element for context
+        parent = element.find_parent(
+            ["p", "div", "li", "dd", "section", "td", "h1", "h2", "h3", "h4", "h5", "h6"]
+        )
+        if parent:
+            details = parent.get_text(strip=True)
+            return {
+                "status": "success",
+                "code": code,
+                "details": details,
+                "metadata": {
+                    "url": f"{url}#{code[0]}xxx",
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "content_type": "text",
+                },
+            }
 
     return {
         "status": "error",

--- a/qiskit-docs-mcp-server/tests/test_data_fetcher.py
+++ b/qiskit-docs-mcp-server/tests/test_data_fetcher.py
@@ -540,6 +540,20 @@ class TestLookupErrorCode:
         assert result["code"] == "3002"
         assert "Queue is full" in result["details"]
 
+    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
+    async def test_code_found_in_heading(self, mock_fetch):
+        """Test finding an error code in a heading element."""
+        mock_fetch.return_value = (
+            "<html><body>"
+            "<h3>Error 4001: Session expired</h3>"
+            "<p>Details about the session timeout.</p>"
+            "</body></html>"
+        )
+        result = await lookup_error_code("4001")
+        assert result["status"] == "success"
+        assert result["code"] == "4001"
+        assert "Session expired" in result["details"]
+
 
 class TestExtractMainContent:
     """Test main content extraction from HTML."""

--- a/qiskit-docs-mcp-server/tests/test_data_fetcher.py
+++ b/qiskit-docs-mcp-server/tests/test_data_fetcher.py
@@ -498,9 +498,7 @@ class TestLookupErrorCode:
     async def test_code_found_in_paragraph(self, mock_fetch):
         """Test finding an error code outside a table, in a paragraph."""
         mock_fetch.return_value = (
-            "<html><body>"
-            "<p>Error 2001: The circuit could not be transpiled.</p>"
-            "</body></html>"
+            "<html><body><p>Error 2001: The circuit could not be transpiled.</p></body></html>"
         )
         result = await lookup_error_code("2001")
         assert result["status"] == "success"

--- a/qiskit-docs-mcp-server/tests/test_data_fetcher.py
+++ b/qiskit-docs-mcp-server/tests/test_data_fetcher.py
@@ -494,6 +494,52 @@ class TestLookupErrorCode:
         assert result["status"] == "error"
         assert "not found" in result["message"]
 
+    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
+    async def test_code_found_in_paragraph(self, mock_fetch):
+        """Test finding an error code outside a table, in a paragraph."""
+        mock_fetch.return_value = (
+            "<html><body>"
+            "<p>Error 2001: The circuit could not be transpiled.</p>"
+            "</body></html>"
+        )
+        result = await lookup_error_code("2001")
+        assert result["status"] == "success"
+        assert result["code"] == "2001"
+        assert "circuit could not be transpiled" in result["details"]
+
+    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
+    async def test_code_found_correct_row_among_multiple(self, mock_fetch):
+        """Test that the correct row is returned when multiple rows exist."""
+        mock_fetch.return_value = (
+            "<table>"
+            "<tr><td>1001</td><td>Timeout error.</td><td>Retry the job.</td></tr>"
+            "<tr><td>1002</td><td>Validation error.</td><td>Check the input.</td></tr>"
+            "<tr><td>1003</td><td>Compilation error.</td><td>Review the circuit.</td></tr>"
+            "</table>"
+        )
+        result = await lookup_error_code("1002")
+        assert result["status"] == "success"
+        assert result["code"] == "1002"
+        assert "Validation error." in result["details"]
+        assert "Check the input." in result["details"]
+        # Make sure we didn't pick up adjacent rows
+        assert "Timeout error." not in result["details"]
+        assert "Compilation error." not in result["details"]
+
+    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text")
+    async def test_code_found_in_list_item(self, mock_fetch):
+        """Test finding an error code in a list item element."""
+        mock_fetch.return_value = (
+            "<html><body><ul>"
+            "<li>3001 - Backend not available.</li>"
+            "<li>3002 - Queue is full.</li>"
+            "</ul></body></html>"
+        )
+        result = await lookup_error_code("3002")
+        assert result["status"] == "success"
+        assert result["code"] == "3002"
+        assert "Queue is full" in result["details"]
+
 
 class TestExtractMainContent:
     """Test main content extraction from HTML."""


### PR DESCRIPTION
## Summary

- Replace the fragile markdown line-search strategy in `lookup_error_code` with direct HTML parsing using BeautifulSoup
- **Strategy 1**: Search table rows for the error code, returning the exact row's cell contents
- **Strategy 2**: Fall back to searching text nodes in block elements (`<p>`, `<li>`, `<div>`, etc.)
- This avoids the +/-2 line context window that could grab content from adjacent error codes
- Add 3 new tests: paragraph fallback, correct row selection among multiple, and list item lookup

Closes #169