### PR TITLE
docs-server: Fix _TTLCache LRU and add separate search cache TTL

### DIFF
--- a/qiskit-docs-mcp-server/README.md
+++ b/qiskit-docs-mcp-server/README.md
@@ -92,6 +92,8 @@ The server can be configured using environment variables:
 |----------|-------------|---------|
 | `QISKIT_DOCS_BASE` | Base URL for Qiskit documentation | `https://quantum.cloud.ibm.com/docs/` |
 | `QISKIT_HTTP_TIMEOUT` | HTTP request timeout in seconds | `10.0` |
+| `QISKIT_DOCS_CACHE_TTL` | Page cache TTL in seconds | `3600.0` |
+| `QISKIT_SEARCH_CACHE_TTL` | Search/JSON cache TTL in seconds | `300.0` |
 | `QISKIT_SEARCH_BASE_URL` | Search API base URL | `https://quantum.cloud.ibm.com/` |
 
 ### Optional Configuration
@@ -102,6 +104,8 @@ Create a `.env` file in the project directory:
 # Optional: Customize documentation URLs
 QISKIT_DOCS_BASE=https://quantum.cloud.ibm.com/docs/
 QISKIT_HTTP_TIMEOUT=15.0
+QISKIT_DOCS_CACHE_TTL=3600.0
+QISKIT_SEARCH_CACHE_TTL=300.0
 ```
 
 ## Quick Start

--- a/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/constants.py
+++ b/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/constants.py
@@ -58,6 +58,7 @@ ERROR_CODE_CATEGORIES = {
 # HTTP timeout configuration (in seconds)
 HTTP_TIMEOUT = _get_env_float("QISKIT_HTTP_TIMEOUT", 10.0)
 CACHE_TTL = _get_env_float("QISKIT_DOCS_CACHE_TTL", 3600.0)
+SEARCH_CACHE_TTL = _get_env_float("QISKIT_SEARCH_CACHE_TTL", 300.0)  # 5 min default
 
 # Qiskit modules and their documentation paths
 AVAILABLE_MODULES = {

--- a/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/data_fetcher.py
+++ b/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/data_fetcher.py
@@ -13,6 +13,7 @@
 import logging
 import re
 import time
+from collections import OrderedDict
 from datetime import datetime, timezone
 from typing import Any
 from urllib.parse import quote, urlparse
@@ -30,6 +31,7 @@ from qiskit_docs_mcp_server.constants import (
     ERROR_CODE_CATEGORIES,
     HTTP_TIMEOUT,
     QISKIT_DOCS_BASE,
+    SEARCH_CACHE_TTL,
     SEARCH_PATH,
 )
 
@@ -46,20 +48,22 @@ class _TTLCache:
     def __init__(self, ttl: float = 3600.0, max_size: int = 128):
         self._ttl = ttl
         self._max_size = max_size
-        self._cache: dict[str, tuple[float, Any]] = {}
+        self._cache: OrderedDict[str, tuple[float, Any]] = OrderedDict()
 
     def get(self, key: str) -> Any | None:
         if key in self._cache:
             timestamp, value = self._cache[key]
             if time.monotonic() - timestamp < self._ttl:
+                self._cache.move_to_end(key)  # LRU touch
                 return value
             del self._cache[key]
         return None
 
     def set(self, key: str, value: Any) -> None:
-        if len(self._cache) >= self._max_size and key not in self._cache:
-            oldest_key = min(self._cache, key=lambda k: self._cache[k][0])
-            del self._cache[oldest_key]
+        if key in self._cache:
+            del self._cache[key]
+        elif len(self._cache) >= self._max_size:
+            self._cache.popitem(last=False)  # Evict LRU — O(1)
         self._cache[key] = (time.monotonic(), value)
 
     def clear(self) -> None:
@@ -67,7 +71,7 @@ class _TTLCache:
 
 
 _text_cache = _TTLCache(ttl=CACHE_TTL)
-_json_cache = _TTLCache(ttl=CACHE_TTL)
+_json_cache = _TTLCache(ttl=SEARCH_CACHE_TTL)
 
 _client_holder: dict[str, httpx.AsyncClient] = {}
 

--- a/qiskit-docs-mcp-server/tests/test_data_fetcher.py
+++ b/qiskit-docs-mcp-server/tests/test_data_fetcher.py
@@ -22,6 +22,7 @@ from qiskit_docs_mcp_server.constants import (
     AVAILABLE_MODULES,
     CACHE_TTL,
     HTTP_TIMEOUT,
+    SEARCH_CACHE_TTL,
     _get_env_float,
 )
 from qiskit_docs_mcp_server.data_fetcher import (
@@ -767,6 +768,10 @@ class TestEnvironmentConfiguration:
         assert CACHE_TTL > 0
         assert CACHE_TTL <= 86400  # At most 24 hours
 
+    def test_search_cache_ttl_default(self):
+        """Test that SEARCH_CACHE_TTL defaults to 300.0 (5 minutes)."""
+        assert SEARCH_CACHE_TTL == 300.0
+
     @patch("qiskit_docs_mcp_server.data_fetcher.httpx.AsyncClient")
     def test_fetch_text_uses_http_timeout(self, mock_client_class):
         """Test that _get_http_client creates client with HTTP_TIMEOUT."""
@@ -857,15 +862,41 @@ class TestCaching:
         assert _text_cache.get("key") is None
 
     def test_cache_evicts_oldest_at_max_size(self):
-        """Test that cache evicts the oldest entry when at capacity."""
+        """Test that cache evicts the LRU entry when at capacity."""
         cache = _TTLCache(ttl=3600.0, max_size=2)
         cache.set("a", 1)
         cache.set("b", 2)
         assert cache.get("a") == 1
         assert cache.get("b") == 2
 
-        # Adding a third entry should evict the oldest ("a")
+        # Adding a third entry should evict LRU ("a", since get("b") was most recent)
         cache.set("c", 3)
         assert cache.get("a") is None
         assert cache.get("b") == 2
         assert cache.get("c") == 3
+
+    def test_cache_lru_eviction_order(self):
+        """Test that LRU eviction respects access order, not insertion order."""
+        cache = _TTLCache(ttl=3600.0, max_size=2)
+        cache.set("a", 1)
+        cache.set("b", 2)
+
+        # Touch "a" so it becomes most recently used
+        assert cache.get("a") == 1
+
+        # Adding "c" should evict "b" (LRU), not "a"
+        cache.set("c", 3)
+        assert cache.get("b") is None  # "b" was evicted (LRU)
+        assert cache.get("a") == 1  # "a" survives (recently accessed)
+        assert cache.get("c") == 3
+
+    def test_cache_update_existing_key_no_eviction(self):
+        """Test that updating an existing key does not evict other entries."""
+        cache = _TTLCache(ttl=3600.0, max_size=2)
+        cache.set("a", 1)
+        cache.set("b", 2)
+
+        # Update "a" with a new value — should not evict "b"
+        cache.set("a", 10)
+        assert cache.get("a") == 10
+        assert cache.get("b") == 2


### PR DESCRIPTION
## Summary
- Replace FIFO eviction with actual LRU using `OrderedDict` (`move_to_end` on get, `popitem(last=False)` for O(1) eviction)
- Add `SEARCH_CACHE_TTL` env var (default 5min) for search/JSON cache, separate from page cache (1hr)
- Add tests for LRU eviction order, cache key updates, and `SEARCH_CACHE_TTL` default

Closes #171