### PR TITLE
docs-server: Include full URLs in resource and search responses

### DIFF
--- a/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/data_fetcher.py
+++ b/qiskit-docs-mcp-server/src/qiskit_docs_mcp_server/data_fetcher.py
@@ -411,12 +411,19 @@ async def search_qiskit_docs(query: str, scope: str = "all") -> dict[str, Any]:
 
     # Strip HTML tags from search result fields (shallow copy to avoid mutating cached data)
     cleaned = []
+    base = QISKIT_DOCS_BASE.rstrip("/")
     for item in results:
         entry = dict(item)
         if "title" in entry:
             entry["title"] = _strip_html_tags(entry["title"])
         if "text" in entry:
             entry["text"] = _strip_html_tags(entry["text"])
+        # Normalize URL to full URL if relative
+        url_val = entry.get("url")
+        if url_val:
+            parsed = urlparse(url_val)
+            if not parsed.scheme and not parsed.netloc:
+                entry["url"] = f"{base}/{url_val.lstrip('/')}"
         cleaned.append(entry)
 
     return {
@@ -497,10 +504,16 @@ async def lookup_error_code(code: str) -> dict[str, Any]:
 
 def get_list_of_modules() -> dict[str, Any]:
     """Get list of all Qiskit SDK modules with descriptions and URL paths."""
+    base = QISKIT_DOCS_BASE.rstrip("/")
     return {
         "status": "success",
         "modules": [
-            {"name": name, "description": desc, "url_path": f"api/qiskit/{name}"}
+            {
+                "name": name,
+                "description": desc,
+                "url_path": f"api/qiskit/{name}",
+                "full_url": f"{base}/api/qiskit/{name}",
+            }
             for name, desc in AVAILABLE_MODULES.items()
         ],
     }
@@ -508,10 +521,16 @@ def get_list_of_modules() -> dict[str, Any]:
 
 def get_list_of_addons() -> dict[str, Any]:
     """Get list of all Qiskit addon modules with descriptions and URL paths."""
+    base = QISKIT_DOCS_BASE.rstrip("/")
     return {
         "status": "success",
         "addons": [
-            {"name": name, "description": desc, "url_path": f"api/qiskit-addon-{name}"}
+            {
+                "name": name,
+                "description": desc,
+                "url_path": f"api/qiskit-addon-{name}",
+                "full_url": f"{base}/api/qiskit-addon-{name}",
+            }
             for name, desc in AVAILABLE_ADDONS.items()
         ],
     }
@@ -519,10 +538,16 @@ def get_list_of_addons() -> dict[str, Any]:
 
 def get_list_of_guides() -> dict[str, Any]:
     """Get list of Qiskit guides and best practices with descriptions and URL paths."""
+    base = QISKIT_DOCS_BASE.rstrip("/")
     return {
         "status": "success",
         "guides": [
-            {"name": name, "description": desc, "url_path": f"guides/{name}"}
+            {
+                "name": name,
+                "description": desc,
+                "url_path": f"guides/{name}",
+                "full_url": f"{base}/guides/{name}",
+            }
             for name, desc in AVAILABLE_GUIDES.items()
         ],
     }

--- a/qiskit-docs-mcp-server/tests/test_data_fetcher.py
+++ b/qiskit-docs-mcp-server/tests/test_data_fetcher.py
@@ -432,6 +432,31 @@ class TestSearchQiskitDocs:
         assert result["status"] == "success"
         assert len(result["results"]) == 1
 
+    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text_json")
+    async def test_search_normalizes_relative_urls(self, mock_fetch):
+        """Test that relative URLs in search results are resolved to full URLs."""
+        mock_fetch.return_value = [
+            {"title": "Circuit", "url": "/docs/api/qiskit/circuit", "text": "Circuit module"},
+        ]
+        result = await search_qiskit_docs("circuit")
+        assert result["status"] == "success"
+        assert result["results"][0]["url"].startswith("https://")
+
+    @patch("qiskit_docs_mcp_server.data_fetcher.fetch_text_json")
+    async def test_search_preserves_absolute_urls(self, mock_fetch):
+        """Test that absolute URLs in search results are preserved as-is."""
+        mock_fetch.return_value = [
+            {
+                "title": "Circuit",
+                "url": "https://quantum.cloud.ibm.com/docs/api/qiskit/circuit",
+                "text": "test",
+            },
+        ]
+        result = await search_qiskit_docs("circuit")
+        assert (
+            result["results"][0]["url"] == "https://quantum.cloud.ibm.com/docs/api/qiskit/circuit"
+        )
+
     async def test_search_invalid_scope_returns_error(self):
         """Test that an invalid scope returns an error without calling the API."""
         result = await search_qiskit_docs("test", scope="invalid")
@@ -641,6 +666,8 @@ class TestListHelpers:
         assert "description" in first
         assert "url_path" in first
         assert first["url_path"].startswith("api/qiskit/")
+        assert "full_url" in first
+        assert first["full_url"].startswith("https://")
 
     def test_get_list_of_addons(self):
         """Test get_list_of_addons returns correct structure with url_path."""
@@ -653,6 +680,7 @@ class TestListHelpers:
         assert "description" in first
         assert "url_path" in first
         assert "qiskit-addon-" in first["url_path"]
+        assert "full_url" in first
 
     def test_get_list_of_guides(self):
         """Test get_list_of_guides returns correct structure with url_path."""
@@ -665,6 +693,7 @@ class TestListHelpers:
         assert "description" in first
         assert "url_path" in first
         assert first["url_path"].startswith("guides/")
+        assert "full_url" in first
 
     def test_get_list_of_error_code_categories(self):
         """Test get_list_of_error_code_categories returns correct structure."""


### PR DESCRIPTION
## Summary
- Add `full_url` field to module, addon, and guide list entries alongside existing `url_path`
- Normalize relative URLs in search results to absolute URLs using `QISKIT_DOCS_BASE`
- Responses are now self-contained — LLMs can present clickable links directly

Closes #173