### PR TITLE
docs-server: Improve test coverage -- TTL expiry, integration tests, reduce private API access

### DIFF
--- a/qiskit-docs-mcp-server/pyproject.toml
+++ b/qiskit-docs-mcp-server/pyproject.toml
@@ -80,6 +80,10 @@ python_classes = "Test*"
 python_functions = "test_*"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
+markers = [
+    "integration: marks tests that hit real APIs (deselect with '-m \"not integration\"')",
+]
+addopts = "-m 'not integration'"
 
 [tool.bandit]
 skips = ["B101"]

--- a/qiskit-docs-mcp-server/tests/test_data_fetcher.py
+++ b/qiskit-docs-mcp-server/tests/test_data_fetcher.py
@@ -25,6 +25,8 @@ from qiskit_docs_mcp_server.constants import (
     _get_env_float,
 )
 from qiskit_docs_mcp_server.data_fetcher import (
+    _client_holder,
+    _get_http_client,
     _json_cache,
     _resolve_url,
     _strip_html_tags,
@@ -869,3 +871,62 @@ class TestCaching:
         assert cache.get("a") is None
         assert cache.get("b") == 2
         assert cache.get("c") == 3
+
+    @patch("qiskit_docs_mcp_server.data_fetcher.time")
+    def test_cache_entry_expires_after_ttl(self, mock_time):
+        """Test that cache entries expire after TTL."""
+        mock_time.monotonic.return_value = 1000.0
+        cache = _TTLCache(ttl=60.0, max_size=10)
+        cache.set("key", "value")
+        assert cache.get("key") == "value"
+
+        # Advance time past TTL
+        mock_time.monotonic.return_value = 1061.0
+        assert cache.get("key") is None
+
+    def test_cache_update_existing_key(self):
+        """Test that updating an existing key doesn't trigger eviction."""
+        cache = _TTLCache(ttl=3600.0, max_size=2)
+        cache.set("a", "1")
+        cache.set("b", "2")
+        cache.set("a", "3")  # Update, not new entry
+        assert cache.get("a") == "3"
+        assert cache.get("b") == "2"
+
+    def test_get_http_client_reuse(self):
+        """Test that _get_http_client returns the same instance on repeated calls."""
+        _client_holder.clear()
+        client1 = _get_http_client()
+        client2 = _get_http_client()
+        assert client1 is client2
+        # Cleanup
+        _client_holder.clear()
+
+
+@pytest.mark.integration
+class TestIntegration:
+    """Integration tests that hit the real Qiskit documentation API.
+
+    Run with: pytest -m integration
+    Skipped by default in CI.
+    """
+
+    async def test_search_docs_live(self):
+        """Test that search returns results from the live API."""
+        result = await search_qiskit_docs("QuantumCircuit")
+        assert result["status"] == "success"
+        assert result["total_results"] > 0
+
+    async def test_get_page_docs_live(self):
+        """Test that page fetch works against the live API."""
+        result = await get_page_docs("api/qiskit/circuit", max_length=1000)
+        assert result["status"] == "success"
+        assert len(result["documentation"]) > 0
+
+    async def test_lookup_error_code_live(self):
+        """Test that error code lookup works against the live API."""
+        result = await lookup_error_code("1002")
+        # May or may not find the code, but should not error
+        assert result["status"] in ("success", "error")
+        if result["status"] == "error":
+            assert "not found" in result["message"].lower() or "Failed" in result["message"]

--- a/qiskit-docs-mcp-server/tests/test_server.py
+++ b/qiskit-docs-mcp-server/tests/test_server.py
@@ -24,6 +24,8 @@ class TestServerRegistration:
 
     def test_tools_registered(self):
         """Test that all expected tools are registered."""
+        # NOTE: Accessing FastMCP internals for introspection. Update if FastMCP
+        # exposes a public API for listing registered tools/resources.
         tool_names = {tool.name for tool in mcp._tool_manager._tools.values()}
         expected_tools = {
             "search_docs_tool",
@@ -34,6 +36,8 @@ class TestServerRegistration:
 
     def test_resources_registered(self):
         """Test that all expected resources are registered."""
+        # NOTE: Accessing FastMCP internals for introspection. Update if FastMCP
+        # exposes a public API for listing registered tools/resources.
         resource_uris = set(mcp._resource_manager._resources.keys())
         expected_resources = {
             "qiskit-docs://modules",
@@ -47,14 +51,20 @@ class TestServerRegistration:
 
     def test_tool_count(self):
         """Test the expected number of tools."""
+        # NOTE: Accessing FastMCP internals for introspection. Update if FastMCP
+        # exposes a public API for listing registered tools/resources.
         assert len(mcp._tool_manager._tools) == 3
 
     def test_resource_count(self):
         """Test the expected number of resources."""
+        # NOTE: Accessing FastMCP internals for introspection. Update if FastMCP
+        # exposes a public API for listing registered tools/resources.
         assert len(mcp._resource_manager._resources) == 4
 
     def test_old_tools_removed(self):
         """Test that old category-specific tools are no longer registered."""
+        # NOTE: Accessing FastMCP internals for introspection. Update if FastMCP
+        # exposes a public API for listing registered tools/resources.
         tool_names = {tool.name for tool in mcp._tool_manager._tools.values()}
         removed_tools = {
             "get_sdk_module_docs_tool",


### PR DESCRIPTION
## Summary
- Add cache TTL expiry test (mocks `time.monotonic` to verify entries expire)
- Add cache update edge case test (updating existing key doesn't trigger eviction)
- Add HTTP client reuse test (`_get_http_client` returns same instance)
- Add optional integration smoke tests (`@pytest.mark.integration`, skipped by default)
- Add fragility comments for FastMCP private API access in test_server.py
- Configure `integration` pytest marker in pyproject.toml

Closes #174