### PR TITLE
docs-server: Document QISKIT_DOCS_CACHE_TTL env var in README

### DIFF
--- a/qiskit-docs-mcp-server/README.md
+++ b/qiskit-docs-mcp-server/README.md
@@ -92,6 +92,7 @@ The server can be configured using environment variables:
 |----------|-------------|---------|
 | `QISKIT_DOCS_BASE` | Base URL for Qiskit documentation | `https://quantum.cloud.ibm.com/docs/` |
 | `QISKIT_HTTP_TIMEOUT` | HTTP request timeout in seconds | `10.0` |
+| `QISKIT_DOCS_CACHE_TTL` | Cache TTL for fetched pages in seconds | `3600.0` |
 | `QISKIT_SEARCH_BASE_URL` | Search API base URL | `https://quantum.cloud.ibm.com/` |
 
 ### Optional Configuration


### PR DESCRIPTION
## Summary
- Add `QISKIT_DOCS_CACHE_TTL` to the environment variables table in the README
- This variable was already configurable in `constants.py` but undocumented