### PR TITLE
feat(code-assistant): add instructions parameter to FastMCP server

### DIFF
--- a/qiskit-code-assistant-mcp-server/src/qiskit_code_assistant_mcp_server/server.py
+++ b/qiskit-code-assistant-mcp-server/src/qiskit_code_assistant_mcp_server/server.py
@@ -49,7 +49,30 @@ logging.basicConfig(level=getattr(logging, QCA_MCP_DEBUG_LEVEL, logging.INFO))
 logger = logging.getLogger(__name__)
 
 # Initialize FastMCP server
-mcp = FastMCP("Qiskit Code Assistant")
+mcp = FastMCP(
+    "Qiskit Code Assistant",
+    instructions="""\
+This server provides access to IBM Qiskit Code Assistant for quantum code \
+generation and conceptual Q&A.
+
+Recommended workflow:
+1. Use get_completion_tool for CODE GENERATION requests (e.g., "write a Bell \
+state circuit", "create VQE code"). It returns ready-to-use Python/Qiskit code.
+2. Use get_rag_completion_tool for CONCEPTUAL QUESTIONS (e.g., "what is \
+entanglement?", "how does the transpiler work?"). It retrieves answers from \
+IBM's knowledge base.
+3. After a successful completion, call accept_completion_tool with the \
+completion_id to provide positive feedback and help improve the service.
+
+Disclaimer handling:
+- Before first use, a model disclaimer may need to be accepted.
+- Browse qca://disclaimer/{model_id} to check disclaimer status, then call \
+accept_model_disclaimer_tool to accept it.
+
+Browse qca://models to discover available models and qca://status to check \
+service health.\
+""",
+)
 
 logger.info("Qiskit Code Assistant MCP Server initialized")
 

--- a/qiskit-code-assistant-mcp-server/tests/test_integration.py
+++ b/qiskit-code-assistant-mcp-server/tests/test_integration.py
@@ -36,6 +36,18 @@ class TestMCPServerIntegration:
         assert mcp.name == "Qiskit Code Assistant"
 
     @pytest.mark.asyncio
+    async def test_server_instructions(self, mock_env_vars):
+        """Test the MCP server has instructions set."""
+        assert mcp.instructions is not None
+        assert isinstance(mcp.instructions, str)
+        assert len(mcp.instructions) > 0
+        # Verify instructions mention key workflow concepts
+        assert "get_completion_tool" in mcp.instructions
+        assert "get_rag_completion_tool" in mcp.instructions
+        assert "accept_completion_tool" in mcp.instructions
+        assert "qca://" in mcp.instructions
+
+    @pytest.mark.asyncio
     async def test_configuration_validation(self, mock_env_vars):
         """Test that configuration validation runs on startup."""
         with patch(


### PR DESCRIPTION
## Summary

- Add `instructions` parameter to the `FastMCP()` constructor to guide LLMs on how to orchestrate tools and resources together
- Instructions describe the recommended workflow: code generation vs RAG for conceptual questions, disclaimer handling flow, feedback via accept_completion, and resource discovery
- Add test verifying instructions are set and mention key workflow concepts

Closes #185