### PR TITLE
feat(ibm-runtime): add instructions parameter to FastMCP server

### DIFF
--- a/qiskit-ibm-runtime-mcp-server/src/qiskit_ibm_runtime_mcp_server/server.py
+++ b/qiskit-ibm-runtime-mcp-server/src/qiskit_ibm_runtime_mcp_server/server.py
@@ -68,7 +68,38 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Initialize MCP server
-mcp = FastMCP("Qiskit IBM Runtime")
+mcp = FastMCP(
+    "Qiskit IBM Runtime",
+    instructions="""\
+This server provides access to IBM Quantum hardware through Qiskit IBM Runtime.
+
+Getting started:
+1. Call setup_ibm_quantum_account_tool to authenticate (or it will attempt \
+to use QISKIT_IBM_TOKEN env var or saved credentials automatically).
+2. Use list_backends_tool to see available backends, or least_busy_backend_tool \
+to quickly find one with a short queue.
+
+Running circuits:
+1. Use run_sampler_tool for measurement sampling (bitstring counts) or \
+run_estimator_tool for expectation value estimation.
+2. Jobs are ASYNCHRONOUS. After submitting, use get_job_status_tool to poll \
+until the job completes, then get_job_results_tool to retrieve results.
+3. Browse circuits:// resources (bell-state, ghz-state, random, superposition) \
+for ready-to-run example circuits.
+
+Backend analysis:
+- Use get_backend_properties_tool for static info (processor type, basis gates, \
+qubit count).
+- Use get_backend_calibration_tool for live calibration data (T1, T2, gate \
+errors, faulty qubits).
+- Use find_optimal_qubit_chains_tool or find_optimal_qv_qubits_tool to select \
+the highest-fidelity qubits for your experiment.
+
+Account management:
+- Use available_instances_tool to see accessible instances and usage_info_tool \
+to check quota and consumption.\
+""",
+)
 
 
 # Tools

--- a/qiskit-ibm-runtime-mcp-server/tests/test_integration.py
+++ b/qiskit-ibm-runtime-mcp-server/tests/test_integration.py
@@ -30,6 +30,19 @@ class TestMCPServerIntegration:
         assert mcp.name == "Qiskit IBM Runtime"
 
     @pytest.mark.asyncio
+    async def test_server_instructions(self, mock_env_vars):
+        """Test the MCP server has instructions set."""
+        assert mcp.instructions is not None
+        assert isinstance(mcp.instructions, str)
+        assert len(mcp.instructions) > 0
+        # Verify instructions mention key workflow concepts
+        assert "setup_ibm_quantum_account_tool" in mcp.instructions
+        assert "run_sampler_tool" in mcp.instructions
+        assert "run_estimator_tool" in mcp.instructions
+        assert "get_job_results_tool" in mcp.instructions
+        assert "circuits://" in mcp.instructions
+
+    @pytest.mark.asyncio
     async def test_service_initialization_flow(
         self, mock_env_vars, mock_runtime_service
     ):


### PR DESCRIPTION
## Summary

- Add `instructions` parameter to the `FastMCP()` constructor to guide LLMs on how to orchestrate tools and resources together
- Instructions describe the recommended workflow: account setup, backend selection, async job execution (run → poll → get results), primitives (sampler vs estimator), example circuit resources, and qubit optimization
- Add test verifying instructions are set and mention key workflow concepts

Closes #187