### PR TITLE
feat(ibm-transpiler): add instructions parameter to FastMCP server

### DIFF
--- a/qiskit-ibm-transpiler-mcp-server/src/qiskit_ibm_transpiler_mcp_server/server.py
+++ b/qiskit-ibm-transpiler-mcp-server/src/qiskit_ibm_transpiler_mcp_server/server.py
@@ -28,7 +28,34 @@ from qiskit_ibm_transpiler_mcp_server.utils import CircuitFormat, setup_ibm_quan
 logger = logging.getLogger(__name__)
 
 # Initialize FastMCP server
-mcp = FastMCP("Qiskit IBM Transpiler")
+mcp = FastMCP(
+    "Qiskit IBM Transpiler",
+    instructions="""\
+This server provides AI-powered quantum circuit transpilation and synthesis \
+using the Qiskit IBM Transpiler Service.
+
+Getting started:
+- Call setup_ibm_quantum_account_tool to authenticate before using other tools.
+
+Quick path (recommended for most users):
+- Use hybrid_ai_transpile_tool for end-to-end transpilation that combines \
+classical heuristic and AI-powered optimization in a single call.
+
+Granular control:
+1. Use ai_routing_tool FIRST to insert SWAP operations and map the circuit \
+to the target backend's connectivity.
+2. Then apply specialized synthesis tools to optimize specific sub-circuit types:
+   - ai_clifford_synthesis_tool: H, S, CX gate blocks (up to 9 qubits)
+   - ai_linear_function_synthesis_tool: CX, SWAP blocks (up to 9 qubits)
+   - ai_permutation_synthesis_tool: SWAP blocks (27, 33, 65 qubits)
+   - ai_pauli_network_synthesis_tool: H, S, SX, CX, RX, RY, RZ blocks \
+(up to 6 qubits)
+
+Tool chaining:
+- All tools output circuit_qpy (base64-encoded QPY) that can be passed \
+directly to the next tool using circuit_format="qpy".\
+""",
+)
 
 logger.info("Qiskit IBM Transpiler MCP Server initialized")
 

--- a/qiskit-ibm-transpiler-mcp-server/tests/integration/test_mcp_server.py
+++ b/qiskit-ibm-transpiler-mcp-server/tests/integration/test_mcp_server.py
@@ -37,6 +37,19 @@ class TestMCPServerIntegration:
 
     @pytest.mark.integration
     @pytest.mark.asyncio
+    async def test_server_instructions(self, mock_env_vars):
+        """Test the MCP server has instructions set."""
+        assert mcp.instructions is not None
+        assert isinstance(mcp.instructions, str)
+        assert len(mcp.instructions) > 0
+        # Verify instructions mention key workflow concepts
+        assert "hybrid_ai_transpile_tool" in mcp.instructions
+        assert "ai_routing_tool" in mcp.instructions
+        assert "ai_clifford_synthesis_tool" in mcp.instructions
+        assert "setup_ibm_quantum_account_tool" in mcp.instructions
+
+    @pytest.mark.integration
+    @pytest.mark.asyncio
     async def test_service_initialization_flow(self, mocker, mock_env_vars, mock_runtime_service):
         """Test service initialization flow."""
         qiskit_runtime_sp = QiskitRuntimeServiceProvider()


### PR DESCRIPTION
## Summary

- Add `instructions` parameter to the `FastMCP()` constructor to guide LLMs on how to orchestrate tools and resources together
- Instructions describe the recommended workflow: account setup, hybrid transpile as quick path, granular route-then-synthesize workflow, and tool chaining via QPY format
- Add test verifying instructions are set and mention key workflow concepts

Closes #188