### PR TITLE
feat(qiskit): add instructions parameter to FastMCP server

### DIFF
--- a/qiskit-mcp-server/src/qiskit_mcp_server/server.py
+++ b/qiskit-mcp-server/src/qiskit_mcp_server/server.py
@@ -53,7 +53,34 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Initialize MCP server
-mcp = FastMCP("Qiskit")
+mcp = FastMCP(
+    "Qiskit",
+    instructions="""\
+This server provides local Qiskit quantum computing capabilities for circuit \
+analysis, transpilation, and format conversion.
+
+Recommended workflow:
+1. Load circuits with load_circuit_from_qasm_tool (accepts both QASM 2.0 and \
+3.0). This validates the circuit and returns metadata (qubit count, depth, \
+gate counts).
+2. Use analyze_circuit_tool to understand circuit complexity before deciding \
+on a transpilation strategy.
+3. Transpile with transpile_circuit_tool. Optimization level 2 is recommended \
+for most circuits. Avoid level 3 for large circuits (100+ qubits or 1000+ \
+gates) as it can be very slow.
+4. Use compare_optimization_levels_tool to see trade-offs across all levels \
+when unsure which optimization level to use.
+
+Format conversion:
+- convert_qpy_to_qasm3_tool: Convert binary QPY output to human-readable QASM3
+- convert_qasm3_to_qpy_tool: Convert QASM to QPY for full circuit fidelity
+- export_circuit_to_qasm_tool: Export QPY circuits to QASM 2.0 or 3.0
+
+Browse qiskit://transpiler/ resources for available basis gate presets \
+(ibm_eagle, ibm_heron, ion_trap, etc.) and coupling map topologies \
+(linear, ring, grid, full).\
+""",
+)
 
 
 # Tools - Only action-oriented tools, metadata is via resources

--- a/qiskit-mcp-server/tests/test_server.py
+++ b/qiskit-mcp-server/tests/test_server.py
@@ -1,0 +1,34 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2025.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for MCP server registration and configuration."""
+
+from qiskit_mcp_server.server import mcp
+
+
+class TestServerRegistration:
+    """Test that the MCP server is configured correctly."""
+
+    def test_server_name(self):
+        """Test the MCP server has the correct name."""
+        assert mcp.name == "Qiskit"
+
+    def test_server_instructions(self):
+        """Test the MCP server has instructions set."""
+        assert mcp.instructions is not None
+        assert isinstance(mcp.instructions, str)
+        assert len(mcp.instructions) > 0
+        # Verify instructions mention key workflow concepts
+        assert "transpile_circuit_tool" in mcp.instructions
+        assert "analyze_circuit_tool" in mcp.instructions
+        assert "load_circuit_from_qasm_tool" in mcp.instructions
+        assert "qiskit://transpiler/" in mcp.instructions


### PR DESCRIPTION
## Summary

- Add `instructions` parameter to the `FastMCP()` constructor to guide LLMs on how to orchestrate tools and resources together
- Instructions describe the recommended workflow: load/analyze circuits before transpilation, optimization level guidance, format conversion, and resource discovery for basis gates and topologies
- Create new `tests/test_server.py` with `test_server_name` and `test_server_instructions` tests

Closes #189