### PR TITLE
qiskit-server: Add MCP prompts

### DIFF
--- a/qiskit-mcp-server/src/qiskit_mcp_server/server.py
+++ b/qiskit-mcp-server/src/qiskit_mcp_server/server.py
@@ -242,6 +242,50 @@ async def export_circuit_to_qasm_tool(
     return export_circuit_to_qasm(circuit_qpy, qasm_version=qasm_version)
 
 
+##################################################
+## MCP Prompts
+## - https://modelcontextprotocol.io/docs/concepts/prompts
+##################################################
+
+
+@mcp.prompt()
+def transpile_for_hardware(circuit: str, backend_type: str) -> str:
+    """Transpile a quantum circuit for a specific hardware type."""
+    return (
+        f"Transpile the circuit for '{backend_type}' hardware: "
+        "1) Read the qiskit://transpiler/basis-gates resource to find the "
+        f"basis gate set for '{backend_type}', "
+        "2) Call transpile_circuit_tool with the circuit, the appropriate "
+        "basis_gates preset, and optimization_level=2, "
+        "3) Report the depth reduction and gate count improvements from the result."
+    )
+
+
+@mcp.prompt()
+def analyze_and_transpile(circuit: str) -> str:
+    """Analyze a quantum circuit and transpile it with the best optimization level."""
+    return (
+        "Analyze and transpile the circuit: "
+        "1) Call analyze_circuit_tool to understand the circuit structure, "
+        "2) Call compare_optimization_levels_tool to find the best trade-off "
+        "between compilation time and circuit quality, "
+        "3) Call transpile_circuit_tool with the recommended optimization level, "
+        "4) Call convert_qpy_to_qasm3_tool to view the final transpiled circuit."
+    )
+
+
+@mcp.prompt()
+def convert_circuit_format(circuit: str, target_format: str) -> str:
+    """Convert a quantum circuit between QASM and QPY formats."""
+    return (
+        f"Convert the circuit to {target_format} format: "
+        "If converting to QPY, call convert_qasm3_to_qpy_tool with the QASM string. "
+        "If converting to QASM3, call convert_qpy_to_qasm3_tool with the base64 QPY. "
+        "If the source format is unknown, call load_circuit_from_qasm_tool first to "
+        "detect and parse it."
+    )
+
+
 # Resources - Static metadata accessible without tool calls
 @mcp.resource("qiskit://transpiler/info", mime_type="application/json")
 async def transpiler_info_resource() -> dict[str, Any]:

--- a/qiskit-mcp-server/tests/test_server.py
+++ b/qiskit-mcp-server/tests/test_server.py
@@ -1,0 +1,73 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for MCP server registration and configuration."""
+
+from qiskit_mcp_server.server import mcp
+
+
+class TestServerRegistration:
+    """Test that tools, resources, and prompts are registered on the MCP server."""
+
+    def test_server_name(self):
+        """Test the server name is correct."""
+        assert mcp.name == "Qiskit"
+
+    def test_tools_registered(self):
+        """Test that all expected tools are registered."""
+        tool_names = {tool.name for tool in mcp._tool_manager._tools.values()}
+        expected_tools = {
+            "transpile_circuit_tool",
+            "analyze_circuit_tool",
+            "compare_optimization_levels_tool",
+            "convert_qpy_to_qasm3_tool",
+            "convert_qasm3_to_qpy_tool",
+            "load_circuit_from_qasm_tool",
+            "export_circuit_to_qasm_tool",
+        }
+        assert expected_tools.issubset(tool_names), f"Missing tools: {expected_tools - tool_names}"
+
+    def test_tool_count(self):
+        """Test the expected number of tools."""
+        assert len(mcp._tool_manager._tools) == 7
+
+    def test_resources_registered(self):
+        """Test that all expected resources are registered."""
+        resource_uris = set(mcp._resource_manager._resources.keys())
+        expected_resources = {
+            "qiskit://transpiler/info",
+            "qiskit://transpiler/basis-gates",
+            "qiskit://transpiler/topologies",
+        }
+        assert expected_resources.issubset(resource_uris), (
+            f"Missing resources: {expected_resources - resource_uris}"
+        )
+
+    def test_resource_count(self):
+        """Test the expected number of resources."""
+        assert len(mcp._resource_manager._resources) == 3
+
+    def test_prompts_registered(self):
+        """Test that all expected prompts are registered."""
+        prompt_names = set(mcp._prompt_manager._prompts.keys())
+        expected_prompts = {
+            "transpile_for_hardware",
+            "analyze_and_transpile",
+            "convert_circuit_format",
+        }
+        assert expected_prompts.issubset(prompt_names), (
+            f"Missing prompts: {expected_prompts - prompt_names}"
+        )
+
+    def test_prompt_count(self):
+        """Test the expected number of prompts."""
+        assert len(mcp._prompt_manager._prompts) == 3


### PR DESCRIPTION
## Summary
- Add 3 MCP prompts (`transpile_for_hardware`, `analyze_and_transpile`, `convert_circuit_format`) for guided transpilation and format conversion workflows
- Add server registration tests

No resource templates added — the existing bulk resources (`basis-gates`, `topologies`) don't have single-item lookup functions in the business layer.

Closes #195