### PR TITLE
chore: bump all servers for v0.10.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qiskit-mcp-servers"
-version = "0.9.0"
+version = "0.10.0"
 description = "Model Context Protocol servers for IBM Quantum services and Qiskit"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/qiskit-code-assistant-mcp-server/pyproject.toml
+++ b/qiskit-code-assistant-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qiskit-code-assistant-mcp-server"
-version = "0.3.0"
+version = "0.4.0"
 description = "MCP server for the Qiskit Code Assistant"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/qiskit-code-assistant-mcp-server/server.json
+++ b/qiskit-code-assistant-mcp-server/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Qiskit/qiskit-code-assistant-mcp-server",
   "title": "Qiskit Code Assistant MCP Server",
   "description": "MCP server for the Qiskit Code Assistant intelligent code completion",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "websiteUrl": "https://github.com/Qiskit/mcp-servers/tree/main/qiskit-code-assistant-mcp-server",
   "repository": {
     "url": "https://github.com/Qiskit/mcp-servers",
@@ -15,7 +15,7 @@
     {
       "registryType": "pypi",
       "identifier": "qiskit-code-assistant-mcp-server",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/qiskit-docs-mcp-server/pyproject.toml
+++ b/qiskit-docs-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qiskit-docs-mcp-server"
-version = "0.1.1"
+version = "0.2.0"
 description = "MCP server for Qiskit documentation retrieval and search"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/qiskit-docs-mcp-server/server.json
+++ b/qiskit-docs-mcp-server/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Qiskit/qiskit-docs-mcp-server",
   "title": "Qiskit Documentation MCP Server",
   "description": "MCP server for querying and retrieving Qiskit documentation, guides, and API references",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "websiteUrl": "https://github.com/Qiskit/mcp-servers/tree/main/qiskit-docs-mcp-server",
   "repository": {
     "url": "https://github.com/Qiskit/mcp-servers",
@@ -15,7 +15,7 @@
     {
       "registryType": "pypi",
       "identifier": "qiskit-docs-mcp-server",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/qiskit-gym-mcp-server/pyproject.toml
+++ b/qiskit-gym-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qiskit-gym-mcp-server"
-version = "0.3.0"
+version = "0.4.0"
 description = "MCP server for qiskit-gym reinforcement learning quantum circuit synthesis"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/qiskit-gym-mcp-server/server.json
+++ b/qiskit-gym-mcp-server/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Qiskit/qiskit-gym-mcp-server",
   "title": "Qiskit Gym MCP Server",
   "description": "MCP server for qiskit-gym reinforcement learning quantum circuit synthesis",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "websiteUrl": "https://github.com/Qiskit/mcp-servers/tree/main/qiskit-gym-mcp-server",
   "repository": {
     "url": "https://github.com/Qiskit/mcp-servers",
@@ -15,7 +15,7 @@
     {
       "registryType": "pypi",
       "identifier": "qiskit-gym-mcp-server",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/qiskit-ibm-runtime-mcp-server/pyproject.toml
+++ b/qiskit-ibm-runtime-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qiskit-ibm-runtime-mcp-server"
-version = "0.5.0"
+version = "0.6.0"
 description = "MCP server for IBM Quantum computing services through Qiskit IBM Runtime"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/qiskit-ibm-runtime-mcp-server/server.json
+++ b/qiskit-ibm-runtime-mcp-server/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Qiskit/qiskit-ibm-runtime-mcp-server",
   "title": "Qiskit IBM Runtime MCP Server",
   "description": "MCP server for IBM Quantum computing services through Qiskit IBM Runtime",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "websiteUrl": "https://github.com/Qiskit/mcp-servers/tree/main/qiskit-ibm-runtime-mcp-server",
   "repository": {
     "url": "https://github.com/Qiskit/mcp-servers",
@@ -15,7 +15,7 @@
     {
       "registryType": "pypi",
       "identifier": "qiskit-ibm-runtime-mcp-server",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/qiskit-ibm-transpiler-mcp-server/pyproject.toml
+++ b/qiskit-ibm-transpiler-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qiskit-ibm-transpiler-mcp-server"
-version = "0.3.1"
+version = "0.4.0"
 description = "MCP server for AI Transpiler IBM Quantum services through local and Qiskit IBM Runtime executions"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/qiskit-ibm-transpiler-mcp-server/server.json
+++ b/qiskit-ibm-transpiler-mcp-server/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Qiskit/qiskit-ibm-transpiler-mcp-server",
   "title": "Qiskit IBM Transpiler MCP Server",
   "description": "MCP server for AI Transpiler IBM Quantum services",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "websiteUrl": "https://github.com/Qiskit/mcp-servers/tree/main/qiskit-ibm-transpiler-mcp-server",
   "repository": {
     "url": "https://github.com/Qiskit/mcp-servers",
@@ -15,7 +15,7 @@
     {
       "registryType": "pypi",
       "identifier": "qiskit-ibm-transpiler-mcp-server",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/qiskit-mcp-server/pyproject.toml
+++ b/qiskit-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qiskit-mcp-server"
-version = "0.2.0"
+version = "0.3.0"
 description = "MCP server for Qiskit quantum computing capabilities with circuit serialization utilities"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/qiskit-mcp-server/server.json
+++ b/qiskit-mcp-server/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Qiskit/qiskit-mcp-server",
   "title": "Qiskit MCP Server",
   "description": "MCP server for Qiskit quantum computing with circuit serialization utilities",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "websiteUrl": "https://github.com/Qiskit/mcp-servers/tree/main/qiskit-mcp-server",
   "repository": {
     "url": "https://github.com/Qiskit/mcp-servers",
@@ -15,7 +15,7 @@
     {
       "registryType": "pypi",
       "identifier": "qiskit-mcp-server",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -4540,7 +4540,7 @@ qpy-compat = [
 
 [[package]]
 name = "qiskit-code-assistant-mcp-server"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "qiskit-code-assistant-mcp-server" }
 dependencies = [
     { name = "fastmcp" },
@@ -4641,7 +4641,7 @@ test = [
 
 [[package]]
 name = "qiskit-docs-mcp-server"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "qiskit-docs-mcp-server" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -4741,7 +4741,7 @@ wheels = [
 
 [[package]]
 name = "qiskit-gym-mcp-server"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "qiskit-gym-mcp-server" }
 dependencies = [
     { name = "fastmcp" },
@@ -4899,7 +4899,7 @@ wheels = [
 
 [[package]]
 name = "qiskit-ibm-runtime-mcp-server"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "qiskit-ibm-runtime-mcp-server" }
 dependencies = [
     { name = "fastmcp" },
@@ -5022,7 +5022,7 @@ wheels = [
 
 [[package]]
 name = "qiskit-ibm-transpiler-mcp-server"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "qiskit-ibm-transpiler-mcp-server" }
 dependencies = [
     { name = "fastmcp" },
@@ -5110,7 +5110,7 @@ test = [
 
 [[package]]
 name = "qiskit-mcp-server"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "qiskit-mcp-server" }
 dependencies = [
     { name = "fastmcp" },
@@ -5205,7 +5205,7 @@ test = [
 
 [[package]]
 name = "qiskit-mcp-servers"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "qiskit-code-assistant-mcp-server" },


### PR DESCRIPTION
## Summary
- Bump all 6 server versions + meta package for the v0.10.0 release
- Update both `pyproject.toml` and MCP registry `server.json` files
- Regenerate `uv.lock`

### Version bumps
| Server | Previous | New |
|--------|----------|-----|
| `qiskit-mcp-servers` (meta) | 0.9.0 | **0.10.0** |
| `qiskit-docs-mcp-server` | 0.1.1 | **0.2.0** |
| `qiskit-mcp-server` | 0.2.0 | **0.3.0** |
| `qiskit-gym-mcp-server` | 0.3.0 | **0.4.0** |
| `qiskit-code-assistant-mcp-server` | 0.3.0 | **0.4.0** |
| `qiskit-ibm-runtime-mcp-server` | 0.5.0 | **0.6.0** |
| `qiskit-ibm-transpiler-mcp-server` | 0.3.1 | **0.4.0** |